### PR TITLE
Update Linux platform macro from linux to __linux__.

### DIFF
--- a/hlsdk/engine/eiface.h
+++ b/hlsdk/engine/eiface.h
@@ -420,11 +420,11 @@ typedef enum _fieldtypes
 	FIELD_TYPECOUNT,		// MUST BE LAST
 } FIELDTYPE;
 
-#ifndef linux
+#ifndef __linux__
 #ifndef offsetof
 #define offsetof(s,m)	(size_t)&(((s *)0)->m)
 #endif
-#endif
+#endif /* !__linux__ */
 
 #define _FIELD(type,name,fieldtype,count,flags)		{ fieldtype, #name, offsetof(type, name), count, flags }
 #define DEFINE_FIELD(type,name,fieldtype)			_FIELD(type, name, fieldtype, 1, 0)

--- a/metamod/commands_meta.cpp
+++ b/metamod/commands_meta.cpp
@@ -351,7 +351,7 @@ void DLLINTERNAL cmd_meta_load(void) {
 		META_CONS("   where <name> is an identifier used to locate the plugin file.");
 		META_CONS("   The system will look for a number of files based on this name, including:");
 		META_CONS("      name");
-#ifdef linux
+#ifdef __linux__
 		META_CONS("      name.so");
 		META_CONS("      name_mm.so");
 		META_CONS("      name_MM.so");
@@ -367,7 +367,7 @@ void DLLINTERNAL cmd_meta_load(void) {
 		META_CONS("      name.dll");
 		META_CONS("      name_mm.dll");
 		META_CONS("      mm_name.dll");
-#endif /* linux */
+#endif /* __linux__ */
 		META_CONS("   in a number of directories, including:");
 		META_CONS("      <gamedir>");
 		META_CONS("      <gamedir>/dlls");

--- a/metamod/game_autodetect.cpp
+++ b/metamod/game_autodetect.cpp
@@ -100,12 +100,12 @@ const char * DLLINTERNAL autodetect_gamedll(const gamedll_t *gamedll, const char
 		if(strstr(buf, "bot.")) {
 			continue;
 		}
-#ifdef linux
+#ifdef __linux__
 		//bot_iX86.so, bot_amd64.so, bot_x86_64.so
 		if(strstr(buf, "bot_i") || strstr(buf, "bot_amd64.so") || strstr(buf, "bot_x86")) {
 			continue;
 		}
-#endif
+#endif /* __linux__ */
 		
 		// Generate full path
 		safevoid_snprintf(fnpath, sizeof(fnpath), "%s/%s", dllpath, ent->d_name);

--- a/metamod/game_support.cpp
+++ b/metamod/game_support.cpp
@@ -72,7 +72,7 @@ const game_modinfo_t * DLLINTERNAL lookup_game(const char *name) {
 			safevoid_snprintf(check_path, sizeof(check_path), "dlls/%s",
 #ifdef _WIN32
 					 imod->win_dll);
-#elif defined(linux)
+#elif defined(__linux__)
 					 imod->linux_so);
 #endif
 
@@ -157,7 +157,7 @@ mBOOL DLLINTERNAL setup_gamedll(gamedll_t *gamedll) {
 	if((known=lookup_game(gamedll->name))) {
 #ifdef _WIN32
 		knownfn=known->win_dll;
-#elif defined(linux)
+#elif defined(__linux__)
 		knownfn=known->linux_so;
 	#ifdef __x86_64__
 		//AMD64: convert _i386.so to _amd64.so
@@ -182,7 +182,7 @@ mBOOL DLLINTERNAL setup_gamedll(gamedll_t *gamedll) {
 		
 		// Do this before autodetecting gamedll from "dlls/*.dll"
 		if(!Config->gamedll) {
-#ifdef linux
+#ifdef __linux__
 			// The engine changed game dll lookup behaviour in that it strips
 			// anything after the last '_' from the name and tries to load the
 			// resulting name. The DSO names were changed and do not have the
@@ -232,7 +232,7 @@ mBOOL DLLINTERNAL setup_gamedll(gamedll_t *gamedll) {
 				META_DEBUG(4, ("Known game DLL name does not qualify for checking for a stripped version, skipping: '%s'.\n",
 								strippedfn) );
 			}
-#endif /* linux */
+#endif /* __linux__ */
 			// If no file to be used was found, try the old known DLL file
 			// name.
 			if (0 == usedfn) {

--- a/metamod/h_export.cpp
+++ b/metamod/h_export.cpp
@@ -54,7 +54,7 @@ extern "C" BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvRe
 	}
 	return(TRUE);
 }
-#elif defined(linux)
+#elif defined(__linux__)
 // Linux routines to correspond to ATTACH and DETACH cases above.  These
 // aren't required by linux, but are included here for completeness, and
 // just in case we come across a need to do something at dll load or
@@ -86,9 +86,9 @@ engine_t Engine;
 C_DLLEXPORT void WINAPI GiveFnptrsToDll(enginefuncs_t *pengfuncsFromEngine, 
 		globalvars_t *pGlobals)
 {
-#ifdef linux
+#ifdef __linux__
 	metamod_handle = get_module_handle_of_memptr((void*)&g_engfuncs);
-#endif
+#endif /* __linux__ */
 	gpGlobals = pGlobals;
 	Engine.funcs = &g_engfuncs;
 	Engine.globals = pGlobals;

--- a/metamod/mlist.cpp
+++ b/metamod/mlist.cpp
@@ -209,7 +209,7 @@ MPlugin * DLLINTERNAL MPluginList::find(const char *findpath) {
 //  - ME_NOTFOUND	couldn't find a matching plugin
 //  - errno's from DLFNAME()
 MPlugin * DLLINTERNAL MPluginList::find_memloc(void *memptr) {
-#ifdef linux
+#ifdef __linux__
 	const char *dlfile;
 
 	if(!memptr)
@@ -232,7 +232,7 @@ MPlugin * DLLINTERNAL MPluginList::find_memloc(void *memptr) {
 	}
 	
 	return(find(dlhandle));
-#endif
+#endif /* __linux__ */
 }
 
 // Find a plugin with non-ambiguous prefix string matching desc, file, 

--- a/metamod/mplugin.cpp
+++ b/metamod/mplugin.cpp
@@ -413,7 +413,7 @@ char * DLLINTERNAL MPlugin::resolve_suffix(const char *path) {
 
 #ifdef _WIN32
 	safevoid_snprintf(buf, sizeof(buf), "%s.dll", path);
-#elif defined(linux)
+#elif defined(__linux__)
 	safevoid_snprintf(buf, sizeof(buf), "%s.so", path);
 #else
 #error "OS unrecognized"
@@ -421,7 +421,7 @@ char * DLLINTERNAL MPlugin::resolve_suffix(const char *path) {
 	if(stat(buf, &st) == 0 && S_ISREG(st.st_mode))
 		return(buf);
 
-#ifdef linux
+#ifdef __linux__
 #ifdef __x86_64__
 	safevoid_snprintf(buf, sizeof(buf), "%s_amd64.so", path);
 	if(stat(buf, &st) == 0 && S_ISREG(st.st_mode))
@@ -446,7 +446,7 @@ char * DLLINTERNAL MPlugin::resolve_suffix(const char *path) {
 	if(stat(buf, &st) == 0 && S_ISREG(st.st_mode))
 		return(buf);
 #endif /* !__x86_64__ */
-#endif /* linux */
+#endif /* __linux__ */
 
 	return(NULL);
 }

--- a/metamod/mreg.cpp
+++ b/metamod/mreg.cpp
@@ -34,12 +34,12 @@
  *
  */
 
-#ifdef linux
+#ifdef __linux__
 // enable extra routines in system header files, like strsignal
 #  ifndef _GNU_SOURCE
 #    define _GNU_SOURCE
 #  endif
-#endif /* linux */
+#endif /* __linux__ */
 
 #include <string.h>			// strsignal, strdup, etc
 #include <errno.h>			// strerror, etc

--- a/metamod/osdep.cpp
+++ b/metamod/osdep.cpp
@@ -34,13 +34,13 @@
  *
  */
 
-#ifdef linux
+#ifdef __linux__
 // enable extra routines in system header files, like dladdr
 #  ifndef _GNU_SOURCE
 #    define _GNU_SOURCE
 #  endif
 #include <dlfcn.h>			// dlopen, dladdr, etc
-#endif /* linux */
+#endif /* __linux__ */
 
 #include <string.h>			// strpbrk, etc
 
@@ -83,7 +83,7 @@ char * DLLINTERNAL my_strtok_r(char *s, const char *delim, char **ptrptr) {
 #endif /* _WIN32 */
 
 
-#ifdef linux
+#ifdef __linux__
 char * DLLINTERNAL my_strlwr(char *s) {
 	char *c;
 	if(!s)
@@ -92,7 +92,7 @@ char * DLLINTERNAL my_strlwr(char *s) {
 		*c = tolower(*c);
 	return(s);
 }
-#endif
+#endif /* __linux__ */
 
 
 #ifndef DO_NOT_FIX_VARARG_ENGINE_API_WARPERS
@@ -244,7 +244,7 @@ char * DLLINTERNAL str_GetLastError(void) {
 
 // Find the filename of the DLL/shared-lib where the given memory location
 // exists.
-#ifdef linux
+#ifdef __linux__
 // Errno values:
 //  - ME_NOTFOUND	couldn't find a sharedlib that contains memory location
 const char * DLLINTERNAL DLFNAME(void *memptr) {
@@ -356,7 +356,7 @@ char * DLLINTERNAL realpath(const char *file_name, char *resolved_name) {
 // Determine whether the given memory location is valid (ie whether we
 // should expect to be able to reference strings or functions at this
 // location without segfaulting).
-#ifdef linux
+#ifdef __linux__
 // Simulate this with dladdr.  I'm not convinced this will be as generally
 // applicable as the native windows routine below, but it should do what
 // we need it for in this particular situation.

--- a/metamod/osdep.h
+++ b/metamod/osdep.h
@@ -49,7 +49,7 @@
 #include "log_meta.h"		// LOG_ERROR, etc
 
 // String describing platform/DLL-type, for matching lines in plugins.ini.
-#ifdef linux
+#ifdef __linux__
 	#define PLATFORM	"linux"
 #  if defined(__x86_64__) || defined(__amd64__)
 	#define PLATFORM_SPC	"lin64"
@@ -87,10 +87,10 @@
 	#endif
 	// WINAPI should be provided in the windows compiler headers.
 	// It's usually defined to something like "__stdcall".
-#elif defined(linux)
+#elif defined(__linux__)
 	#define DLLEXPORT	__attribute__ ((visibility ("default"), externally_visible))
 	#define WINAPI		/* */
-#endif /* linux */
+#endif /* __linux__ */
 
 // Simplified macro for declaring/defining exported DLL functions.  They
 // need to be 'extern "C"' so that the C++ compiler enforces parameter
@@ -111,7 +111,7 @@ void DLLINTERNAL safevoid_snprintf(char* s, size_t n, const char* format, ...);
 
 // Functions & types for DLL open/close/etc operations.
 extern mBOOL dlclose_handle_invalid DLLHIDDEN;
-#ifdef linux
+#ifdef __linux__
 	#include <dlfcn.h>
 	typedef void* DLHANDLE;
 	typedef void* DLFUNC;
@@ -182,10 +182,10 @@ mBOOL DLLINTERNAL os_safe_call(REG_CMD_FN pfn);
 
 
 // Linux doesn't have an strlwr() routine, so we write our own.
-#ifdef linux
+#ifdef __linux__
 	#define strlwr(s) my_strlwr(s)
 	char * DLLINTERNAL my_strlwr(char *s);
-#endif /* _WIN32 */
+#endif /* __linux__ */
 
 
 // Set filename and pathname maximum lengths.  Note some windows compilers
@@ -195,7 +195,7 @@ mBOOL DLLINTERNAL os_safe_call(REG_CMD_FN pfn);
 // Note that both OS's include room for null-termination:
 //   linux:    "# chars in a path name including nul"
 //   win32:    "note that the sizes include space for 0-terminator"
-#ifdef linux
+#ifdef __linux__
 	#include <limits.h>
 #elif defined(_WIN32)
 	#include <stdlib.h>
@@ -206,7 +206,7 @@ mBOOL DLLINTERNAL os_safe_call(REG_CMD_FN pfn);
 #endif /* _WIN32 */
 
 // Various other windows routine differences.
-#ifdef linux
+#ifdef __linux__
 	#include <unistd.h>	// sleep
 	#ifndef O_BINARY
     		#define O_BINARY 0
@@ -270,7 +270,7 @@ mBOOL DLLINTERNAL os_safe_call(REG_CMD_FN pfn);
 //      non-case-sensitive.
 //  - For linux, this requires no work, as paths uses slashes (/) natively,
 //    and pathnames are case-sensitive.
-#ifdef linux
+#ifdef __linux__
 #define normalize_pathname(a)
 #elif defined(_WIN32)
 void DLLINTERNAL normalize_pathname(char *path);
@@ -300,7 +300,7 @@ char * DLLINTERNAL realpath(const char *file_name, char *resolved_name);
 // Generic "error string" from a recent OS call.  For linux, this is based
 // on errno.  For win32, it's based on GetLastError.
 inline const char * DLLINTERNAL str_os_error(void) {
-#ifdef linux
+#ifdef __linux__
 	return(strerror(errno));
 #elif defined(_WIN32)
 	return(str_GetLastError());

--- a/metamod/osdep_p.cpp
+++ b/metamod/osdep_p.cpp
@@ -29,13 +29,13 @@
  *
  */
 
-#ifdef linux
+#ifdef __linux__
 // enable extra routines in system header files, like dladdr
 #  ifndef _GNU_SOURCE
 #    define _GNU_SOURCE
 #  endif
 #include <dlfcn.h>			// dlopen, dladdr, etc
-#endif /* linux */
+#endif /* __linux__ */
 
 #include <extdll.h>			// always
 
@@ -96,7 +96,7 @@ void DLLINTERNAL my_closedir(DIR *dir)
 #endif /* _WIN32 */
 
 //get module handle of memptr
-#ifdef linux
+#ifdef __linux__
 DLHANDLE DLLINTERNAL get_module_handle_of_memptr(void * memptr)
 {
 	Dl_info dli;
@@ -121,4 +121,4 @@ DLHANDLE DLLINTERNAL get_module_handle_of_memptr(void * memptr)
 	
 	return((DLHANDLE)MBI.AllocationBase);	
 }
-#endif /* linux */
+#endif /* __linux__ */

--- a/metamod/osdep_p.h
+++ b/metamod/osdep_p.h
@@ -69,8 +69,8 @@ mBOOL DLLINTERNAL is_gamedll(const char *filename);
 
 DLHANDLE DLLINTERNAL get_module_handle_of_memptr(void * memptr);
 
-#ifdef linux
+#ifdef __linux__
 	void * DLLINTERNAL get_dlsym_pointer(void);
-#endif
+#endif /* __linux__ */
 
 #endif /* OSDEP_P_H */

--- a/metamod/reg_support.cpp
+++ b/metamod/reg_support.cpp
@@ -35,12 +35,12 @@
  *
  */
 
-#ifdef linux
+#ifdef __linux__
 // enable extra routines in system header files, like strsignal
 #  ifndef _GNU_SOURCE
 #    define _GNU_SOURCE
 #  endif
-#endif /* linux */
+#endif /* __linux__ */
 
 #include <string.h>			// strsignal, etc
 


### PR DESCRIPTION
The linux definition still works but it looks like linux is being phased out in favour of __linux__ (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65128)

I wasn't able to get gcc to set linux as a predefined definition in https://github.com/tschumann/sandbot (I guess there's some flag which enables it) so it's probably better to use the new and correct definition name.