### PR TITLE
Add CI verification of Win32 DLL exports and imports

### DIFF
--- a/.github/scripts/check_dll.py
+++ b/.github/scripts/check_dll.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Verify Win32 DLL exports and imports.
+
+Usage: check_dll.py <dll> <export>... [-- <dll> <export>... ...]
+
+Checks that each DLL has the required exports and only imports from
+KERNEL32.dll and msvcrt.dll.
+"""
+
+import sys
+import os
+import pefile
+
+ALLOWED_IMPORTS = {"KERNEL32.dll", "msvcrt.dll"}
+
+
+def check_dll(dll_path, required_exports):
+    name = os.path.basename(dll_path)
+    failed = False
+
+    pe = pefile.PE(dll_path)
+
+    exports = set()
+    if hasattr(pe, "DIRECTORY_ENTRY_EXPORT"):
+        for exp in pe.DIRECTORY_ENTRY_EXPORT.symbols:
+            if exp.name:
+                exports.add(exp.name.decode())
+
+    imports = set()
+    if hasattr(pe, "DIRECTORY_ENTRY_IMPORT"):
+        for entry in pe.DIRECTORY_ENTRY_IMPORT:
+            imports.add(entry.dll.decode())
+
+    pe.close()
+
+    print(f"--- {name} ---")
+    print(f"  Exports: {sorted(exports)}")
+    print(f"  Imports: {sorted(imports)}")
+
+    for sym in required_exports:
+        if sym not in exports:
+            print(f"::error::{name}: missing required export: {sym}")
+            failed = True
+
+    for imp in imports:
+        if imp not in ALLOWED_IMPORTS:
+            print(f"::error::{name}: unexpected DLL import: {imp}")
+            failed = True
+
+    return failed
+
+
+def main():
+    args = sys.argv[1:]
+    if not args:
+        print(__doc__)
+        sys.exit(1)
+
+    groups = []
+    current = []
+    for arg in args:
+        if arg == "--":
+            if current:
+                groups.append(current)
+            current = []
+        else:
+            current.append(arg)
+    if current:
+        groups.append(current)
+
+    failed = False
+    for group in groups:
+        dll_path = group[0]
+        required_exports = group[1:]
+        if check_dll(dll_path, required_exports):
+            failed = True
+
+    sys.exit(1 if failed else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -114,6 +114,21 @@ jobs:
         run: make -j4 -C stub_plugin CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
       - name: Build wdmisc_plugin (optimized)
         run: make -j4 -C wdmisc_plugin CC_WIN="i686-w64-mingw32-g++" OS=windows OPT=opt win32
+      - name: Verify Win32 DLL exports and imports
+        run: |
+          pip install pefile
+          python3 -u .github/scripts/check_dll.py \
+            metamod/opt.win32/metamod.dll \
+              GiveFnptrsToDll GetEntityAPI GetEntityAPI2 GetNewDLLFunctions \
+            -- \
+            trace_plugin/opt.win32/trace_mm.dll \
+              GiveFnptrsToDll Meta_Query Meta_Attach Meta_Detach \
+            -- \
+            stub_plugin/opt.win32/stub_mm.dll \
+              GiveFnptrsToDll Meta_Query Meta_Attach Meta_Detach \
+            -- \
+            wdmisc_plugin/opt.win32/wdmisc_mm.dll \
+              GiveFnptrsToDll Meta_Query Meta_Attach Meta_Detach
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/metamod/Makefile
+++ b/metamod/Makefile
@@ -276,7 +276,7 @@ TARGET_LINUX = $(OBJDIR_LINUX)/$(LIBFILE_LINUX)
 # windows .dll compile commands
 DO_CC_WIN=$(CC_WIN) $(CFLAGS) $(INCLUDEDIRS) -o $@ -c $<
 DO_RES_WIN=$(RES_WIN) '$(ODEF)' $(META_DEFS_RES) --include-dir . --include-dir ../metamod -i $< -O coff -o $@
-LINK_WIN=$(CC_WIN) $(CFLAGS) -mdll -Xlinker --add-stdcall-alias $(EXTRA_LINK) $(OBJ_WIN) $(RES_OBJ_WIN) -s -o $@
+LINK_WIN=$(CC_WIN) $(CFLAGS) -mdll -Xlinker --add-stdcall-alias -static-libgcc $(EXTRA_LINK) $(OBJ_WIN) $(RES_OBJ_WIN) -s -o $@
 
 # windows object files
 OBJ_WIN := $(SRCFILES:%.cpp=$(OBJDIR_WIN)/%.o)


### PR DESCRIPTION
## Summary

- Add post-build CI step that verifies all Win32 DLLs have required PE exports and no unexpected DLL import dependencies
- Uses `pefile` Python library to parse PE headers directly (avoids `objdump` text format differences across binutils versions)
- metamod.dll: must export `GiveFnptrsToDll`, `GetEntityAPI`, `GetEntityAPI2`, `GetNewDLLFunctions`
- Plugins: must export `GiveFnptrsToDll`, `Meta_Query`, `Meta_Attach`, `Meta_Detach`
- Only `KERNEL32.dll` and `msvcrt.dll` imports allowed
- Add `-static-libgcc` to `LINK_WIN` to eliminate `libgcc_s_dw2-1.dll` runtime dependency from plugin builds

Would have caught #103 (empty export table from mingw `__attribute__((externally_visible))`).

## Test plan

- [x] Verified locally: all 4 DLLs pass export and import checks
- [x] Linux build unaffected
- [ ] CI passes