### PR TITLE
Fix SIGSEGV when hook list rebuilt mid-iteration (issue #108)

### DIFF
--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -36,6 +36,7 @@
 #include "types_meta.h"
 #include "api_info.h"
 #include "api_hook.h"
+#include "mlist.h"
 #include "mplugin.h"
 #include "metamod.h"
 #include "osdep.h"			//unlikely
@@ -94,6 +95,8 @@ inline const api_info_t * DLLINTERNAL get_api_info(enum_api_t api, unsigned int 
   #define MAYBE_META_DEBUG(do_debug, level, args) do { break; } while(0)
 #endif
 
+HOT_DATA static DLLHIDDEN int reentry_count;
+
 // simplified 'void' version of main hook function
 template <bool do_debug>
 static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
@@ -103,6 +106,7 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 	MPlugin * const *plugs;
 	META_RES status;
 	meta_globals_t saved_meta_globals;
+	mBOOL rebuild_happened = mFALSE;
 
 	//passing offset from api wrapper function makes code faster/smaller
 	api_info = *get_api_info(api, api_info_offset);
@@ -113,18 +117,22 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 
 	//Setup
 	status=MRES_UNSET;
+	if (likely(reentry_count++ == 0))
+		hook_list_tables_updated = mFALSE;
 
 	//Pre plugin functions
 	PublicMetaGlobals.prev_mres=MRES_UNSET;
+	rebuild_happened = hook_list_tables_updated;
 	list = Plugins->get_hook_list(api);
 	count = list->count;
 	plugs = list->plugs;
 	for(i=0; likely(i < count); i++) {
-		void *pfn_routine=get_api_function(plugs[i]->get_api_table(api), func_offset);
+		MPlugin *plug = plugs[i];
+		void *pfn_routine=get_api_function(plug->get_api_table(api), func_offset);
 		if(likely(!pfn_routine))
 			continue;
 
-		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plugs[i]->file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plug->file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -133,6 +141,12 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 		// call plugin
 		api_info.api_caller(pfn_routine, packed_args);
 		API_UNPAUSE_TSC_TRACKING();
+
+		if(unlikely(hook_list_tables_updated)) {
+			hook_list_tables_updated = mFALSE;
+			rebuild_happened = mTRUE;
+			i = Plugins->find_plugin_after_rebuild(api, mFALSE, plug, count, plugs);
+		}
 
 		// plugin's result code
 		META_RES mres=PublicMetaGlobals.mres;
@@ -143,7 +157,7 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 		PublicMetaGlobals.prev_mres = mres;
 
 		if(unlikely(mres==MRES_UNSET))
-			META_WARNING("Plugin didn't set meta_result: %s:%s()", plugs[i]->file, api_info.name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s()", plug->file, api_info.name);
 	}
 
 	//Api call
@@ -174,15 +188,18 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 
 	//Post plugin functions
 	PublicMetaGlobals.prev_mres=MRES_UNSET;
+	rebuild_happened = (mBOOL)(rebuild_happened | hook_list_tables_updated);
+	hook_list_tables_updated = mFALSE;
 	list = Plugins->get_hook_post_list(api);
 	count = list->count;
 	plugs = list->plugs;
 	for(i=0; likely(i < count); i++) {
-		void *pfn_routine=get_api_function(plugs[i]->get_api_post_table(api), func_offset);
+		MPlugin *plug = plugs[i];
+		void *pfn_routine=get_api_function(plug->get_api_post_table(api), func_offset);
 		if(likely(!pfn_routine))
 			continue;
 
-		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plugs[i]->file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plug->file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -191,6 +208,12 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 		// call plugin
 		api_info.api_caller(pfn_routine, packed_args);
 		API_UNPAUSE_TSC_TRACKING();
+
+		if(unlikely(hook_list_tables_updated)) {
+			hook_list_tables_updated = mFALSE;
+			rebuild_happened = mTRUE;
+			i = Plugins->find_plugin_after_rebuild(api, mTRUE, plug, count, plugs);
+		}
 
 		// plugin's result code
 		META_RES mres=PublicMetaGlobals.mres;
@@ -201,12 +224,16 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 		PublicMetaGlobals.prev_mres = mres;
 
 		if(unlikely(mres==MRES_UNSET))
-			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", plugs[i]->file, api_info.name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", plug->file, api_info.name);
 		else if(unlikely(mres==MRES_SUPERCEDE))
-			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plugs[i]->file, api_info.name);
+			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plug->file, api_info.name);
 	}
 
 	copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);
+	if(unlikely(rebuild_happened))
+		hook_list_tables_updated = mTRUE;
+	if (likely(--reentry_count == 0))
+		hook_list_tables_updated = mFALSE;
 }
 
 HOT_FUNC void DLLINTERNAL NOINLINE main_hook_function_void(unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args) {
@@ -228,6 +255,7 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 	MPlugin * const *plugs;
 	META_RES status;
 	meta_globals_t saved_meta_globals;
+	mBOOL rebuild_happened = mFALSE;
 	struct {
 	  class_ret_t orig_ret;
 	  class_ret_t override_ret;
@@ -246,18 +274,22 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 
 	//Setup
 	status=MRES_UNSET;
+	if (likely(reentry_count++ == 0))
+		hook_list_tables_updated = mFALSE;
 
 	//Pre plugin functions
 	PublicMetaGlobals.prev_mres = MRES_UNSET;
+	rebuild_happened = hook_list_tables_updated;
 	list = Plugins->get_hook_list(api);
 	count = list->count;
 	plugs = list->plugs;
 	for(i=0; likely(i < count); i++) {
-		void *pfn_routine=get_api_function(plugs[i]->get_api_table(api), func_offset);
+		MPlugin *plug = plugs[i];
+		void *pfn_routine=get_api_function(plug->get_api_table(api), func_offset);
 		if(likely(!pfn_routine))
 			continue;
 
-		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plugs[i]->file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plug->file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -273,6 +305,12 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 
 		rv = backup_rv;
 
+		if(unlikely(hook_list_tables_updated)) {
+			hook_list_tables_updated = mFALSE;
+			rebuild_happened = mTRUE;
+			i = Plugins->find_plugin_after_rebuild(api, mFALSE, plug, count, plugs);
+		}
+
 		// plugin's result code
 		META_RES mres=PublicMetaGlobals.mres;
 		if(unlikely(mres > status))
@@ -285,7 +323,7 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 			rv.override_ret = dllret;
 		}
 		else if(unlikely(mres==MRES_UNSET)) {
-			META_WARNING("Plugin didn't set meta_result: %s:%s()", plugs[i]->file, api_info.name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s()", plug->file, api_info.name);
 		}
 	}
 
@@ -320,15 +358,18 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 
 	//Post plugin functions
 	PublicMetaGlobals.prev_mres = MRES_UNSET;
+	rebuild_happened = (mBOOL)(rebuild_happened | hook_list_tables_updated);
+	hook_list_tables_updated = mFALSE;
 	list = Plugins->get_hook_post_list(api);
 	count = list->count;
 	plugs = list->plugs;
 	for(i=0; likely(i < count); i++) {
-		void *pfn_routine=get_api_function(plugs[i]->get_api_post_table(api), func_offset);
+		MPlugin *plug = plugs[i];
+		void *pfn_routine=get_api_function(plug->get_api_post_table(api), func_offset);
 		if(likely(!pfn_routine))
 			continue;
 
-		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plugs[i]->file, api_info.name));
+		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plug->file, api_info.name));
 
 		// initialize PublicMetaGlobals
 		PublicMetaGlobals.mres = MRES_UNSET;
@@ -344,6 +385,12 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 
 		rv = backup_rv;
 
+		if(unlikely(hook_list_tables_updated)) {
+			hook_list_tables_updated = mFALSE;
+			rebuild_happened = mTRUE;
+			i = Plugins->find_plugin_after_rebuild(api, mTRUE, plug, count, plugs);
+		}
+
 		// plugin's result code
 		META_RES mres=PublicMetaGlobals.mres;
 		if(unlikely(mres > status))
@@ -356,14 +403,18 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 			rv.override_ret = dllret;
 		}
 		else if(unlikely(mres==MRES_UNSET)) {
-			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", plugs[i]->file, api_info.name);
+			META_WARNING("Plugin didn't set meta_result: %s:%s_Post()", plug->file, api_info.name);
 		}
 		else if(unlikely(mres==MRES_SUPERCEDE)) {
-			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plugs[i]->file, api_info.name);
+			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plug->file, api_info.name);
 		}
 	}
 
 	copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);
+	if(unlikely(rebuild_happened))
+		hook_list_tables_updated = mTRUE;
+	if (likely(--reentry_count == 0))
+		hook_list_tables_updated = mFALSE;
 
 	//return value is passed through ret_init!
 	if(likely(status!=MRES_OVERRIDE)) {

--- a/metamod/mlist.cpp
+++ b/metamod/mlist.cpp
@@ -48,8 +48,10 @@
 #include "osdep.h"				// win32 snprintf, normalize_pathname,
 #include "osdep_p.h"
 
+HOT_DATA mBOOL DLLHIDDEN hook_list_tables_updated = mFALSE;
+
 // Constructor
-MPluginList::MPluginList(const char *ifile) 
+MPluginList::MPluginList(const char *ifile)
 	: size(MAX_PLUGINS), endlist(0)
 {
 	int i;
@@ -224,6 +226,8 @@ void DLLINTERNAL MPluginList::rebuild_hook_lists(void) {
 				hook_lists[api][1].plugs[idx[api][1]++] = &plist[i];
 		}
 	}
+
+	hook_list_tables_updated = mTRUE;
 }
 
 // Find a plugin with the given plid.

--- a/metamod/mlist.h
+++ b/metamod/mlist.h
@@ -56,6 +56,10 @@ struct api_plugin_list_t {
 	MPlugin **plugs;
 };
 
+// Set by rebuild_hook_lists() to signal main_hook_function that cached
+// pointers are stale and need to be refreshed.
+extern mBOOL DLLHIDDEN hook_list_tables_updated;
+
 // A list of plugins.
 class MPluginList : public class_metamod_new {
 	public:
@@ -72,6 +76,21 @@ class MPluginList : public class_metamod_new {
 		}
 		inline DLLINTERNAL const api_plugin_list_t * get_hook_post_list(enum_api_t api) {
 			return(&hook_lists[api][1]);
+		}
+		inline DLLINTERNAL int find_plugin_after_rebuild(
+			enum_api_t api, mBOOL post, MPlugin *current_plugin,
+			int &out_count, MPlugin * const * &out_plugs)
+		{
+			const api_plugin_list_t *list = &hook_lists[api][post ? 1 : 0];
+			out_plugs = list->plugs;
+			out_count = list->count;
+			for(int j = 0; j < out_count; j++) {
+				if(out_plugs[j] == current_plugin)
+					return j;
+				if(out_plugs[j] > current_plugin)
+					return j - 1;
+			}
+			return out_count - 1;
 		}
 
 	// constructor/destructor:

--- a/metamod/tests/Makefile
+++ b/metamod/tests/Makefile
@@ -81,7 +81,7 @@ test_vdate: test_vdate.o
 	${CXX} $(EXTRA_FLAGS) -o $@ $^
 
 test_api_hook: test_api_hook.o $(EXTENDED_OBJS) api_hook.o api_info.o dllapi.o
-	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl -Wl,--wrap=realloc
 
 test_api_info: test_api_info.o $(EXTENDED_OBJS) api_info.o api_hook.o
 	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl

--- a/metamod/tests/test_api_hook.cpp
+++ b/metamod/tests/test_api_hook.cpp
@@ -9,6 +9,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stddef.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include <extdll.h>
 
@@ -27,6 +30,23 @@
 // Plugins normally get this pointer via Meta_Query/Meta_Attach.
 // Point it at metamod's PublicMetaGlobals so RETURN_META works.
 meta_globals_t *gpMetaGlobals = &PublicMetaGlobals;
+
+// Wrap realloc to always move the allocation (exposes use-after-free bugs).
+static size_t last_realloc_old_size = 0;
+extern "C" void *__real_realloc(void *ptr, size_t size);
+extern "C" void *__wrap_realloc(void *ptr, size_t size)
+{
+	void *newptr = malloc(size);
+	if (!newptr)
+		return NULL;
+	if (ptr) {
+		memcpy(newptr, ptr, size);
+		memset(ptr, 0, last_realloc_old_size);
+		free(ptr);
+	}
+	last_realloc_old_size = size;
+	return newptr;
+}
 
 // ============================================================
 // Test tracking state
@@ -125,10 +145,56 @@ static int plugin2_pre_Spawn(edict_t *)
 }
 
 // ============================================================
+// Callbacks that trigger rebuild_hook_lists (issue #108)
+// ============================================================
+
+static DLL_FUNCTIONS plugin3_pre_funcs;
+static DLL_FUNCTIONS plugin3_post_funcs;
+
+static void plugin1_pre_GameInit_load_plugin3(void)
+{
+	g_plugin1_pre_called++;
+
+	// Simulate AMXX loading a new module from within a hook callback:
+	// activate plugin3 and call rebuild_hook_lists().
+	MPlugin *plug3 = &Plugins->plist[2];
+	memset(plug3, 0, sizeof(*plug3));
+	plug3->status = PL_RUNNING;
+	plug3->index = 3;
+	snprintf(plug3->filename, sizeof(plug3->filename), "plugin3");
+	plug3->file = plug3->filename;
+	plug3->tables.dllapi = &plugin3_pre_funcs;
+	plug3->post_tables.dllapi = &plugin3_post_funcs;
+	Plugins->endlist = 3;
+	Plugins->rebuild_hook_lists();
+
+	RETURN_META(MRES_IGNORED);
+}
+
+static void plugin1_post_GameInit_load_plugin3(void)
+{
+	g_plugin1_post_called++;
+
+	// Same as above but triggered from post hook path.
+	MPlugin *plug3 = &Plugins->plist[2];
+	memset(plug3, 0, sizeof(*plug3));
+	plug3->status = PL_RUNNING;
+	plug3->index = 3;
+	snprintf(plug3->filename, sizeof(plug3->filename), "plugin3");
+	plug3->file = plug3->filename;
+	plug3->tables.dllapi = &plugin3_pre_funcs;
+	plug3->post_tables.dllapi = &plugin3_post_funcs;
+	Plugins->endlist = 3;
+	Plugins->rebuild_hook_lists();
+
+	RETURN_META(MRES_IGNORED);
+}
+
+// ============================================================
 // Infrastructure: set up a MPluginList with mock plugins
 // ============================================================
 
-static MPluginList test_plugins("plugins.ini");
+MPluginList test_plugins("plugins.ini");
 static MRegCmdList test_reg_cmds;
 static MRegCvarList test_reg_cvars;
 static MRegMsgList test_reg_msgs;
@@ -1150,6 +1216,70 @@ static int test_return_null_pre_table(void)
 }
 
 // ============================================================
+// Issue #108: rebuild_hook_lists during iteration segfaults
+// ============================================================
+
+static int test_rebuild_during_pre_hook_segfaults(void)
+{
+	TEST("issue #108 - rebuild during pre hook iteration segfaults");
+	setup_two_plugins();
+
+	// plugin1 pre hook triggers rebuild (loads plugin3), invalidating
+	// the cached plugs pointer. plugin2's pre hook then dereferences
+	// the stale pointer → SIGSEGV.
+	plugin1_pre_funcs.pfnGameInit = plugin1_pre_GameInit_load_plugin3;
+	plugin2_pre_funcs.pfnGameInit = plugin2_pre_GameInit;
+	g_plugin2_pre_mres = MRES_IGNORED;
+	memset(&plugin3_pre_funcs, 0, sizeof(plugin3_pre_funcs));
+	memset(&plugin3_post_funcs, 0, sizeof(plugin3_post_funcs));
+
+	pid_t pid = fork();
+	if (pid == 0) {
+		call_hooked_GameInit();
+		_exit(0);
+	}
+
+	int status = 0;
+	waitpid(pid, &status, 0);
+	ASSERT_TRUE(WIFSIGNALED(status));
+	ASSERT_TRUE(WTERMSIG(status) == SIGSEGV);
+
+	teardown();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_during_post_hook_segfaults(void)
+{
+	TEST("issue #108 - rebuild during post hook iteration segfaults");
+	setup_two_plugins();
+
+	// plugin1 post hook triggers rebuild (loads plugin3), invalidating
+	// the cached plugs pointer. plugin2's post hook then dereferences
+	// the stale pointer → SIGSEGV.
+	plugin1_post_funcs.pfnGameInit = plugin1_post_GameInit_load_plugin3;
+	plugin2_post_funcs.pfnGameInit = plugin2_post_GameInit;
+	g_plugin2_post_mres = MRES_IGNORED;
+	memset(&plugin3_pre_funcs, 0, sizeof(plugin3_pre_funcs));
+	memset(&plugin3_post_funcs, 0, sizeof(plugin3_post_funcs));
+
+	pid_t pid = fork();
+	if (pid == 0) {
+		call_hooked_GameInit();
+		_exit(0);
+	}
+
+	int status = 0;
+	waitpid(pid, &status, 0);
+	ASSERT_TRUE(WIFSIGNALED(status));
+	ASSERT_TRUE(WTERMSIG(status) == SIGSEGV);
+
+	teardown();
+	PASS();
+	return 0;
+}
+
+// ============================================================
 // main
 // ============================================================
 
@@ -1223,6 +1353,10 @@ int main(void)
 	// NULL table tests
 	fail |= test_void_null_post_table();
 	fail |= test_return_null_pre_table();
+
+	// Issue #108: rebuild during hook iteration
+	fail |= test_rebuild_during_pre_hook_segfaults();
+	fail |= test_rebuild_during_post_hook_segfaults();
 
 	printf("\n%d/%d tests passed\n", tests_passed, tests_run);
 	return fail ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/metamod/tests/test_api_hook.cpp
+++ b/metamod/tests/test_api_hook.cpp
@@ -40,7 +40,8 @@ extern "C" void *__wrap_realloc(void *ptr, size_t size)
 	if (!newptr)
 		return NULL;
 	if (ptr) {
-		memcpy(newptr, ptr, size);
+		size_t copy_size = size < last_realloc_old_size ? size : last_realloc_old_size;
+		memcpy(newptr, ptr, copy_size);
 		memset(ptr, 0, last_realloc_old_size);
 		free(ptr);
 	}
@@ -194,7 +195,7 @@ static void plugin1_post_GameInit_load_plugin3(void)
 // Infrastructure: set up a MPluginList with mock plugins
 // ============================================================
 
-MPluginList test_plugins("plugins.ini");
+static MPluginList test_plugins("plugins.ini");
 static MRegCmdList test_reg_cmds;
 static MRegCvarList test_reg_cvars;
 static MRegMsgList test_reg_msgs;
@@ -1216,17 +1217,16 @@ static int test_return_null_pre_table(void)
 }
 
 // ============================================================
-// Issue #108: rebuild_hook_lists during iteration segfaults
+// Issue #108: rebuild_hook_lists during iteration
 // ============================================================
 
-static int test_rebuild_during_pre_hook_segfaults(void)
+static int test_rebuild_during_pre_hook_survives(void)
 {
-	TEST("issue #108 - rebuild during pre hook iteration segfaults");
+	TEST("issue #108 - rebuild during pre hook iteration does not crash");
 	setup_two_plugins();
 
-	// plugin1 pre hook triggers rebuild (loads plugin3), invalidating
-	// the cached plugs pointer. plugin2's pre hook then dereferences
-	// the stale pointer → SIGSEGV.
+	// plugin1 pre hook triggers rebuild (loads plugin3).
+	// Without fix, plugin2's pre hook would dereference stale pointer → SIGSEGV.
 	plugin1_pre_funcs.pfnGameInit = plugin1_pre_GameInit_load_plugin3;
 	plugin2_pre_funcs.pfnGameInit = plugin2_pre_GameInit;
 	g_plugin2_pre_mres = MRES_IGNORED;
@@ -1241,22 +1241,21 @@ static int test_rebuild_during_pre_hook_segfaults(void)
 
 	int status = 0;
 	waitpid(pid, &status, 0);
-	ASSERT_TRUE(WIFSIGNALED(status));
-	ASSERT_TRUE(WTERMSIG(status) == SIGSEGV);
+	ASSERT_TRUE(WIFEXITED(status));
+	ASSERT_TRUE(WEXITSTATUS(status) == 0);
 
 	teardown();
 	PASS();
 	return 0;
 }
 
-static int test_rebuild_during_post_hook_segfaults(void)
+static int test_rebuild_during_post_hook_survives(void)
 {
-	TEST("issue #108 - rebuild during post hook iteration segfaults");
+	TEST("issue #108 - rebuild during post hook iteration does not crash");
 	setup_two_plugins();
 
-	// plugin1 post hook triggers rebuild (loads plugin3), invalidating
-	// the cached plugs pointer. plugin2's post hook then dereferences
-	// the stale pointer → SIGSEGV.
+	// plugin1 post hook triggers rebuild (loads plugin3).
+	// Without fix, plugin2's post hook would dereference stale pointer → SIGSEGV.
 	plugin1_post_funcs.pfnGameInit = plugin1_post_GameInit_load_plugin3;
 	plugin2_post_funcs.pfnGameInit = plugin2_post_GameInit;
 	g_plugin2_post_mres = MRES_IGNORED;
@@ -1271,8 +1270,311 @@ static int test_rebuild_during_post_hook_segfaults(void)
 
 	int status = 0;
 	waitpid(pid, &status, 0);
-	ASSERT_TRUE(WIFSIGNALED(status));
-	ASSERT_TRUE(WTERMSIG(status) == SIGSEGV);
+	ASSERT_TRUE(WIFEXITED(status));
+	ASSERT_TRUE(WEXITSTATUS(status) == 0);
+
+	teardown();
+	PASS();
+	return 0;
+}
+
+// ============================================================
+// Tests: re-entrancy flag propagation (reentry_count)
+// ============================================================
+
+// Scenario: outer pre hook calls engine function which re-enters the
+// dispatcher. The inner call triggers rebuild_hook_lists. The outer call
+// must still detect the rebuild and refresh its iteration state.
+
+static int g_plugin3_pre_called;
+static int g_plugin3_post_called;
+
+static void plugin3_pre_GameInit(void)
+{
+	g_plugin3_pre_called++;
+	RETURN_META(MRES_IGNORED);
+}
+
+static void plugin3_post_GameInit(void)
+{
+	g_plugin3_post_called++;
+	RETURN_META(MRES_IGNORED);
+}
+
+static void plugin1_pre_reenter_and_rebuild(void)
+{
+	g_plugin1_pre_called++;
+
+	// Remove our hook to avoid infinite recursion
+	plugin1_pre_funcs.pfnGameInit = NULL;
+
+	// Re-enter the dispatcher (inner call)
+	DLL_FUNCTIONS inner_funcs;
+	memset(&inner_funcs, 0, sizeof(inner_funcs));
+	int ver = INTERFACE_VERSION;
+	GetEntityAPI2(&inner_funcs, &ver);
+	inner_funcs.pfnGameInit();
+
+	// After inner call returns, load plugin3 and rebuild.
+	// This simulates: plugin hook -> engine call -> dllapi re-entry ->
+	// return -> plugin continues and loads another plugin.
+	MPlugin *plug3 = &Plugins->plist[2];
+	memset(plug3, 0, sizeof(*plug3));
+	plug3->status = PL_RUNNING;
+	plug3->index = 3;
+	snprintf(plug3->filename, sizeof(plug3->filename), "plugin3");
+	plug3->file = plug3->filename;
+	plugin3_pre_funcs.pfnGameInit = plugin3_pre_GameInit;
+	plugin3_post_funcs.pfnGameInit = plugin3_post_GameInit;
+	plug3->tables.dllapi = &plugin3_pre_funcs;
+	plug3->post_tables.dllapi = &plugin3_post_funcs;
+	Plugins->endlist = 3;
+	Plugins->rebuild_hook_lists();
+
+	RETURN_META(MRES_IGNORED);
+}
+
+static int test_reentry_rebuild_propagates_to_outer_pre(void)
+{
+	TEST("issue #108 - nested call + rebuild after return propagates to outer pre loop");
+	setup_two_plugins();
+	plugin1_pre_funcs.pfnGameInit = plugin1_pre_reenter_and_rebuild;
+	plugin2_pre_funcs.pfnGameInit = plugin2_pre_GameInit;
+	g_plugin2_pre_mres = MRES_IGNORED;
+	g_plugin3_pre_called = 0;
+	g_plugin3_post_called = 0;
+	memset(&plugin3_pre_funcs, 0, sizeof(plugin3_pre_funcs));
+	memset(&plugin3_post_funcs, 0, sizeof(plugin3_post_funcs));
+
+	pid_t pid = fork();
+	if (pid == 0) {
+		call_hooked_GameInit();
+		_exit(0);
+	}
+
+	int status = 0;
+	waitpid(pid, &status, 0);
+	// Must not crash — outer loop must detect rebuild and refresh
+	ASSERT_TRUE(WIFEXITED(status));
+	ASSERT_TRUE(WEXITSTATUS(status) == 0);
+
+	teardown();
+	PASS();
+	return 0;
+}
+
+static void plugin1_post_reenter_and_rebuild(void)
+{
+	g_plugin1_post_called++;
+
+	// Remove our hook to avoid infinite recursion
+	plugin1_post_funcs.pfnGameInit = NULL;
+
+	// Re-enter the dispatcher (inner call)
+	DLL_FUNCTIONS inner_funcs;
+	memset(&inner_funcs, 0, sizeof(inner_funcs));
+	int ver = INTERFACE_VERSION;
+	GetEntityAPI2(&inner_funcs, &ver);
+	inner_funcs.pfnGameInit();
+
+	// After inner call returns, load plugin3 and rebuild
+	MPlugin *plug3 = &Plugins->plist[2];
+	memset(plug3, 0, sizeof(*plug3));
+	plug3->status = PL_RUNNING;
+	plug3->index = 3;
+	snprintf(plug3->filename, sizeof(plug3->filename), "plugin3");
+	plug3->file = plug3->filename;
+	plugin3_pre_funcs.pfnGameInit = plugin3_pre_GameInit;
+	plugin3_post_funcs.pfnGameInit = plugin3_post_GameInit;
+	plug3->tables.dllapi = &plugin3_pre_funcs;
+	plug3->post_tables.dllapi = &plugin3_post_funcs;
+	Plugins->endlist = 3;
+	Plugins->rebuild_hook_lists();
+
+	RETURN_META(MRES_IGNORED);
+}
+
+static int test_reentry_rebuild_propagates_to_outer_post(void)
+{
+	TEST("issue #108 - nested call + rebuild after return propagates to outer post loop");
+	setup_two_plugins();
+	plugin1_post_funcs.pfnGameInit = plugin1_post_reenter_and_rebuild;
+	plugin2_post_funcs.pfnGameInit = plugin2_post_GameInit;
+	g_plugin2_post_mres = MRES_IGNORED;
+	g_plugin3_pre_called = 0;
+	g_plugin3_post_called = 0;
+	memset(&plugin3_pre_funcs, 0, sizeof(plugin3_pre_funcs));
+	memset(&plugin3_post_funcs, 0, sizeof(plugin3_post_funcs));
+
+	pid_t pid = fork();
+	if (pid == 0) {
+		call_hooked_GameInit();
+		_exit(0);
+	}
+
+	int status = 0;
+	waitpid(pid, &status, 0);
+	ASSERT_TRUE(WIFEXITED(status));
+	ASSERT_TRUE(WEXITSTATUS(status) == 0);
+
+	teardown();
+	PASS();
+	return 0;
+}
+
+// Verify that hook_list_tables_updated is cleared after the outermost
+// call returns (no stale flag left for unrelated future calls).
+
+static void plugin1_pre_just_rebuild(void)
+{
+	g_plugin1_pre_called++;
+
+	MPlugin *plug3 = &Plugins->plist[2];
+	memset(plug3, 0, sizeof(*plug3));
+	plug3->status = PL_RUNNING;
+	plug3->index = 3;
+	snprintf(plug3->filename, sizeof(plug3->filename), "plugin3");
+	plug3->file = plug3->filename;
+	plugin3_pre_funcs.pfnGameInit = plugin3_pre_GameInit;
+	plug3->tables.dllapi = &plugin3_pre_funcs;
+	plug3->post_tables.dllapi = &plugin3_post_funcs;
+	Plugins->endlist = 3;
+	Plugins->rebuild_hook_lists();
+
+	RETURN_META(MRES_IGNORED);
+}
+
+static int test_flag_cleared_after_outermost_returns(void)
+{
+	TEST("issue #108 - hook_list_tables_updated cleared after outermost call returns");
+	setup_two_plugins();
+	plugin1_pre_funcs.pfnGameInit = plugin1_pre_just_rebuild;
+	plugin2_pre_funcs.pfnGameInit = plugin2_pre_GameInit;
+	g_plugin2_pre_mres = MRES_IGNORED;
+	g_plugin3_pre_called = 0;
+	memset(&plugin3_pre_funcs, 0, sizeof(plugin3_pre_funcs));
+	memset(&plugin3_post_funcs, 0, sizeof(plugin3_post_funcs));
+
+	call_hooked_GameInit();
+	// After the call completes, the flag must be cleared
+	ASSERT_TRUE(hook_list_tables_updated == mFALSE);
+
+	teardown();
+	PASS();
+	return 0;
+}
+
+// Return-typed version: nested call with rebuild must propagate
+
+static int plugin1_pre_Spawn_reenter_and_rebuild(edict_t *ed)
+{
+	g_plugin1_pre_called++;
+
+	plugin1_pre_funcs.pfnSpawn = NULL;
+
+	DLL_FUNCTIONS inner_funcs;
+	memset(&inner_funcs, 0, sizeof(inner_funcs));
+	int ver = INTERFACE_VERSION;
+	GetEntityAPI2(&inner_funcs, &ver);
+	inner_funcs.pfnSpawn(ed);
+
+	// After inner call, rebuild
+	MPlugin *plug3 = &Plugins->plist[2];
+	memset(plug3, 0, sizeof(*plug3));
+	plug3->status = PL_RUNNING;
+	plug3->index = 3;
+	snprintf(plug3->filename, sizeof(plug3->filename), "plugin3");
+	plug3->file = plug3->filename;
+	plugin3_pre_funcs.pfnGameInit = NULL;
+	plug3->tables.dllapi = &plugin3_pre_funcs;
+	plug3->post_tables.dllapi = &plugin3_post_funcs;
+	Plugins->endlist = 3;
+	Plugins->rebuild_hook_lists();
+
+	RETURN_META_VALUE(MRES_IGNORED, 0);
+}
+
+static int test_reentry_rebuild_propagates_return_type(void)
+{
+	TEST("issue #108 - nested rebuild propagates in return-typed dispatch");
+	setup_two_plugins();
+	plugin1_pre_funcs.pfnSpawn = plugin1_pre_Spawn_reenter_and_rebuild;
+	plugin2_pre_funcs.pfnSpawn = plugin2_pre_Spawn;
+	g_plugin2_pre_mres = MRES_IGNORED;
+	memset(&plugin3_pre_funcs, 0, sizeof(plugin3_pre_funcs));
+	memset(&plugin3_post_funcs, 0, sizeof(plugin3_post_funcs));
+
+	pid_t pid = fork();
+	if (pid == 0) {
+		call_hooked_Spawn();
+		_exit(0);
+	}
+
+	int status = 0;
+	waitpid(pid, &status, 0);
+	ASSERT_TRUE(WIFEXITED(status));
+	ASSERT_TRUE(WEXITSTATUS(status) == 0);
+
+	teardown();
+	PASS();
+	return 0;
+}
+
+// Verify nested call does NOT clear the flag that was already set before entry
+
+static void plugin1_pre_set_flag_then_reenter(void)
+{
+	g_plugin1_pre_called++;
+
+	// Trigger rebuild first (sets flag)
+	MPlugin *plug3 = &Plugins->plist[2];
+	memset(plug3, 0, sizeof(*plug3));
+	plug3->status = PL_RUNNING;
+	plug3->index = 3;
+	snprintf(plug3->filename, sizeof(plug3->filename), "plugin3");
+	plug3->file = plug3->filename;
+	plugin3_pre_funcs.pfnGameInit = plugin3_pre_GameInit;
+	plugin3_post_funcs.pfnGameInit = plugin3_post_GameInit;
+	plug3->tables.dllapi = &plugin3_pre_funcs;
+	plug3->post_tables.dllapi = &plugin3_post_funcs;
+	Plugins->endlist = 3;
+	Plugins->rebuild_hook_lists();
+	// flag is now set
+
+	// Re-enter — inner call must NOT clobber the flag for outer
+	plugin1_pre_funcs.pfnGameInit = NULL;
+	DLL_FUNCTIONS inner_funcs;
+	memset(&inner_funcs, 0, sizeof(inner_funcs));
+	int ver = INTERFACE_VERSION;
+	GetEntityAPI2(&inner_funcs, &ver);
+	inner_funcs.pfnGameInit();
+
+	RETURN_META(MRES_IGNORED);
+}
+
+static int test_reentry_does_not_clobber_outer_flag(void)
+{
+	TEST("issue #108 - nested call does not clear flag set before re-entry");
+	setup_two_plugins();
+	plugin1_pre_funcs.pfnGameInit = plugin1_pre_set_flag_then_reenter;
+	plugin2_pre_funcs.pfnGameInit = plugin2_pre_GameInit;
+	g_plugin2_pre_mres = MRES_IGNORED;
+	g_plugin3_pre_called = 0;
+	g_plugin3_post_called = 0;
+	memset(&plugin3_pre_funcs, 0, sizeof(plugin3_pre_funcs));
+	memset(&plugin3_post_funcs, 0, sizeof(plugin3_post_funcs));
+
+	pid_t pid = fork();
+	if (pid == 0) {
+		call_hooked_GameInit();
+		_exit(0);
+	}
+
+	int status = 0;
+	waitpid(pid, &status, 0);
+	// Outer call must detect the rebuild (set before re-entry) and not crash
+	ASSERT_TRUE(WIFEXITED(status));
+	ASSERT_TRUE(WEXITSTATUS(status) == 0);
 
 	teardown();
 	PASS();
@@ -1355,8 +1657,15 @@ int main(void)
 	fail |= test_return_null_pre_table();
 
 	// Issue #108: rebuild during hook iteration
-	fail |= test_rebuild_during_pre_hook_segfaults();
-	fail |= test_rebuild_during_post_hook_segfaults();
+	fail |= test_rebuild_during_pre_hook_survives();
+	fail |= test_rebuild_during_post_hook_survives();
+
+	// Issue #108: re-entrancy flag propagation
+	fail |= test_reentry_rebuild_propagates_to_outer_pre();
+	fail |= test_reentry_rebuild_propagates_to_outer_post();
+	fail |= test_flag_cleared_after_outermost_returns();
+	fail |= test_reentry_rebuild_propagates_return_type();
+	fail |= test_reentry_does_not_clobber_outer_flag();
 
 	printf("\n%d/%d tests passed\n", tests_passed, tests_run);
 	return fail ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/metamod/tests/test_mlist.cpp
+++ b/metamod/tests/test_mlist.cpp
@@ -34,8 +34,8 @@ extern "C" void *__wrap_realloc(void *ptr, size_t size)
 	if (!newptr)
 		return NULL;
 	if (ptr) {
-		memcpy(newptr, ptr, size);
-		// Zero old memory to make use-after-free deterministic (NULL derefs).
+		size_t copy_size = size < last_realloc_old_size ? size : last_realloc_old_size;
+		memcpy(newptr, ptr, copy_size);
 		memset(ptr, 0, last_realloc_old_size);
 		free(ptr);
 	}
@@ -4598,15 +4598,1134 @@ static int test_rebuild_endlist_bounds(void)
 }
 
 // ============================================================
+// find_plugin_after_rebuild (issue #108)
+// ============================================================
+
+// Tests for the index fixup function used by main_hook_function after
+// rebuild_hook_lists is called mid-iteration. Verifies correct new index
+// for all combinations of plugin load/unload/pause during a hook callback.
+//
+// The for loop in main_hook_function does i++ after the returned index,
+// so "return X" means next iteration processes plugs[X+1].
+
+static DLL_FUNCTIONS fake_dllapi3;
+static DLL_FUNCTIONS fake_dllapi4;
+static DLL_FUNCTIONS fake_dllapi5;
+
+// Case 1: [A,B,C] idx=0(A), C removed → [A,B]. A stays at 0.
+static int test_find_after_rebuild_later_removed(void)
+{
+	TEST("find_plugin_after_rebuild - later plugin removed, no shift");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	// Simulate: at idx=0 calling A, C gets removed, rebuild
+	int count = list->get_hook_list(e_api_dllapi)->count;
+	MPlugin * const *plugs = list->get_hook_list(e_api_dllapi)->plugs;
+	ASSERT_INT(count, 3);
+
+	plugC->status = PL_EMPTY; plugC->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugA, count, plugs);
+	ASSERT_INT(new_i, 0);
+	ASSERT_INT(count, 2);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 2: [A,B,C] idx=1(B), C removed → [A,B]. B stays at 1.
+static int test_find_after_rebuild_later_removed2(void)
+{
+	TEST("find_plugin_after_rebuild - later plugin removed, mid-list");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	plugC->status = PL_EMPTY; plugC->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 1);
+	ASSERT_INT(count, 2);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 3: [A,B] idx=0(A), D added after B → [A,B,D]. A stays at 0.
+static int test_find_after_rebuild_later_added(void)
+{
+	TEST("find_plugin_after_rebuild - later plugin added, no shift");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+
+	// Add D at plist[3] (after B)
+	MPlugin *plugD = &list->plist[3];
+	memset(plugD, 0, sizeof(*plugD)); plugD->index = 4;
+	plugD->status = PL_RUNNING; plugD->tables.dllapi = &fake_dllapi4;
+	list->endlist = 4;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugA, count, plugs);
+	ASSERT_INT(new_i, 0);
+	ASSERT_INT(count, 3);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 4: [A,B,C] idx=2(C), A removed → [B,C]. C shifts to 1.
+static int test_find_after_rebuild_earlier_removed(void)
+{
+	TEST("find_plugin_after_rebuild - earlier removed, shift left");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugC, count, plugs);
+	ASSERT_INT(new_i, 1);
+	ASSERT_INT(count, 2);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 5: [A,B,C] idx=2(C), A paused → [B,C]. C shifts to 1.
+static int test_find_after_rebuild_earlier_paused(void)
+{
+	TEST("find_plugin_after_rebuild - earlier paused, shift left");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_PAUSED;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugC, count, plugs);
+	ASSERT_INT(new_i, 1);
+	ASSERT_INT(count, 2);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 6: [A,B,C] idx=2(C), A and B removed → [C]. C shifts to 0.
+static int test_find_after_rebuild_two_earlier_removed(void)
+{
+	TEST("find_plugin_after_rebuild - two earlier removed, shift left by 2");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	plugB->status = PL_EMPTY; plugB->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugC, count, plugs);
+	ASSERT_INT(new_i, 0);
+	ASSERT_INT(count, 1);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 7: [A,B,C] idx=1(B), A removed → [B,C]. B shifts to 0.
+static int test_find_after_rebuild_earlier_removed_mid(void)
+{
+	TEST("find_plugin_after_rebuild - earlier removed, mid-list shifts left");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 0);
+	ASSERT_INT(count, 2);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 8: [A,B] idx=1(B), A removed → [B]. B shifts to 0.
+static int test_find_after_rebuild_earlier_removed_becomes_first(void)
+{
+	TEST("find_plugin_after_rebuild - earlier removed, becomes first");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 0);
+	ASSERT_INT(count, 1);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 9: [A,B] idx=0(A), X added before A in plist → [X,A,B]. A shifts to 1.
+static int test_find_after_rebuild_earlier_added(void)
+{
+	TEST("find_plugin_after_rebuild - earlier added, shift right");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+
+	// plist[0] = empty slot for X (added later)
+	// plist[1] = A, plist[2] = B
+	MPlugin *plugA = &list->plist[1];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 2;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[2];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 3;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	// Add X at plist[0] (before A)
+	MPlugin *plugX = &list->plist[0];
+	memset(plugX, 0, sizeof(*plugX)); plugX->index = 1;
+	plugX->status = PL_RUNNING; plugX->tables.dllapi = &fake_dllapi4;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugA, count, plugs);
+	ASSERT_INT(new_i, 1);
+	ASSERT_INT(count, 3);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 10: [A,B] idx=1(B), X added before A in plist → [X,A,B]. B shifts to 2.
+static int test_find_after_rebuild_earlier_added_last(void)
+{
+	TEST("find_plugin_after_rebuild - earlier added, last shifts right");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+
+	MPlugin *plugA = &list->plist[1];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 2;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[2];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 3;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	MPlugin *plugX = &list->plist[0];
+	memset(plugX, 0, sizeof(*plugX)); plugX->index = 1;
+	plugX->status = PL_RUNNING; plugX->tables.dllapi = &fake_dllapi4;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 2);
+	ASSERT_INT(count, 3);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 11: [A,B] idx=1(B), X added between A and B → [A,X,B]. B shifts to 2.
+static int test_find_after_rebuild_added_between(void)
+{
+	TEST("find_plugin_after_rebuild - plugin added between, shift right");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+
+	// plist[0] = A, plist[1] empty for X, plist[2] = B
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[2];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 3;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	// Add X at plist[1] (between A and B)
+	MPlugin *plugX = &list->plist[1];
+	memset(plugX, 0, sizeof(*plugX)); plugX->index = 2;
+	plugX->status = PL_RUNNING; plugX->tables.dllapi = &fake_dllapi4;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 2);
+	ASSERT_INT(count, 3);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 12: [A,B] idx=0(A), two plugins added before A → [X,Y,A,B]. A shifts to 2.
+static int test_find_after_rebuild_two_earlier_added(void)
+{
+	TEST("find_plugin_after_rebuild - two earlier added, shift right by 2");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	memset(&fake_dllapi5, 0, sizeof(fake_dllapi5));
+
+	// plist[0],[1] empty for X,Y; plist[2] = A, plist[3] = B
+	MPlugin *plugA = &list->plist[2];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 3;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[3];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 4;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 4;
+	list->rebuild_hook_lists();
+
+	MPlugin *plugX = &list->plist[0];
+	memset(plugX, 0, sizeof(*plugX)); plugX->index = 1;
+	plugX->status = PL_RUNNING; plugX->tables.dllapi = &fake_dllapi4;
+
+	MPlugin *plugY = &list->plist[1];
+	memset(plugY, 0, sizeof(*plugY)); plugY->index = 2;
+	plugY->status = PL_RUNNING; plugY->tables.dllapi = &fake_dllapi5;
+
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugA, count, plugs);
+	ASSERT_INT(new_i, 2);
+	ASSERT_INT(count, 4);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 13: [A,B] idx=1(B), paused plugin before B unpaused → [A,X,B]. B shifts to 2.
+static int test_find_after_rebuild_earlier_unpaused(void)
+{
+	TEST("find_plugin_after_rebuild - earlier unpaused, shift right");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+
+	// plist[0] = A, plist[1] = X (paused), plist[2] = B
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugX = &list->plist[1];
+	memset(plugX, 0, sizeof(*plugX)); plugX->index = 2;
+	plugX->status = PL_PAUSED; plugX->tables.dllapi = &fake_dllapi4;
+
+	MPlugin *plugB = &list->plist[2];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 3;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+	// Hook list is [A, B] (X paused)
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 2);
+
+	// Unpause X
+	plugX->status = PL_RUNNING;
+	list->rebuild_hook_lists();
+	// Hook list is [A, X, B]
+	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 3);
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 2);
+	ASSERT_INT(count, 3);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 14: [A] idx=0(A), A removed → []. Self gone, list empty. Return -1.
+static int test_find_after_rebuild_self_removed_only(void)
+{
+	TEST("find_plugin_after_rebuild - self removed, was only plugin");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	list->endlist = 1;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugA, count, plugs);
+	// i=-1, loop does i++ → 0, 0<0 false, loop ends
+	ASSERT_INT(new_i, -1);
+	ASSERT_INT(count, 0);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 15: [A,B] idx=0(A), A removed → [B]. Return -1 so i++→0 processes B.
+static int test_find_after_rebuild_self_removed_first(void)
+{
+	TEST("find_plugin_after_rebuild - self removed, was first of two");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugA, count, plugs);
+	// i=-1, loop does i++ → 0, processes plugs[0]=B
+	ASSERT_INT(new_i, -1);
+	ASSERT_INT(count, 1);
+	ASSERT_PTR_EQ(plugs[0], plugB);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 16: [A,B,C] idx=1(B), B removed → [A,C]. Return 0 so i++→1 processes C.
+static int test_find_after_rebuild_self_removed_mid(void)
+{
+	TEST("find_plugin_after_rebuild - self removed from middle");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	plugB->status = PL_EMPTY; plugB->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	// i=0, loop does i++ → 1, processes plugs[1]=C
+	ASSERT_INT(new_i, 0);
+	ASSERT_INT(count, 2);
+	ASSERT_PTR_EQ(plugs[1], plugC);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 17: [A,B,C] idx=1(B), B paused → [A,C]. Return 0 so i++→1 processes C.
+static int test_find_after_rebuild_self_paused_mid(void)
+{
+	TEST("find_plugin_after_rebuild - self paused from middle");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	plugB->status = PL_PAUSED;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 0);
+	ASSERT_INT(count, 2);
+	ASSERT_PTR_EQ(plugs[1], plugC);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 18: [A,B,C] idx=1(B), A removed + D added after C → [B,C,D]. B at 0.
+static int test_find_after_rebuild_mixed_remove_add_later(void)
+{
+	TEST("find_plugin_after_rebuild - earlier removed + later added");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	MPlugin *plugD = &list->plist[3];
+	memset(plugD, 0, sizeof(*plugD)); plugD->index = 4;
+	plugD->status = PL_RUNNING; plugD->tables.dllapi = &fake_dllapi4;
+	list->endlist = 4;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 0);
+	ASSERT_INT(count, 3);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 19: [A,B,C] idx=1(B), A removed + X added before A → [X,B,C]. Net zero for B.
+static int test_find_after_rebuild_mixed_remove_add_earlier(void)
+{
+	TEST("find_plugin_after_rebuild - removed + added before, net zero");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+
+	// plist[0] empty for X, plist[1] = A, plist[2] = B, plist[3] = C
+	MPlugin *plugA = &list->plist[1];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 2;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[2];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 3;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[3];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 4;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 4;
+	list->rebuild_hook_lists();
+	// Hook list: [A, B, C]
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	MPlugin *plugX = &list->plist[0];
+	memset(plugX, 0, sizeof(*plugX)); plugX->index = 1;
+	plugX->status = PL_RUNNING; plugX->tables.dllapi = &fake_dllapi4;
+	list->rebuild_hook_lists();
+	// Hook list: [X, B, C]
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 1);
+	ASSERT_INT(count, 3);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 20: [A,B,C] idx=2(C), A removed + X added before A → [X,B,C]. C at 2.
+static int test_find_after_rebuild_mixed_last_net_zero(void)
+{
+	TEST("find_plugin_after_rebuild - removed + added before, last stays");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+
+	// plist[0] empty for X, plist[1] = A, plist[2] = B, plist[3] = C
+	MPlugin *plugA = &list->plist[1];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 2;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[2];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 3;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[3];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 4;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 4;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	MPlugin *plugX = &list->plist[0];
+	memset(plugX, 0, sizeof(*plugX)); plugX->index = 1;
+	plugX->status = PL_RUNNING; plugX->tables.dllapi = &fake_dllapi4;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugC, count, plugs);
+	ASSERT_INT(new_i, 2);
+	ASSERT_INT(count, 3);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 21: [A,B,C] idx=0(A), B removed + X added before A → [X,A,C]. A at 1.
+static int test_find_after_rebuild_mixed_add_before_remove_after(void)
+{
+	TEST("find_plugin_after_rebuild - added before + later removed");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+
+	// plist[0] empty for X, plist[1] = A, plist[2] = B, plist[3] = C
+	MPlugin *plugA = &list->plist[1];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 2;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[2];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 3;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[3];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 4;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 4;
+	list->rebuild_hook_lists();
+
+	plugB->status = PL_EMPTY; plugB->tables.dllapi = NULL;
+	MPlugin *plugX = &list->plist[0];
+	memset(plugX, 0, sizeof(*plugX)); plugX->index = 1;
+	plugX->status = PL_RUNNING; plugX->tables.dllapi = &fake_dllapi4;
+	list->rebuild_hook_lists();
+	// Hook list: [X, A, C]
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugA, count, plugs);
+	ASSERT_INT(new_i, 1);
+	ASSERT_INT(count, 3);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 22: [A,B,C] idx=1(B), A and C removed → [B]. B at 0.
+static int test_find_after_rebuild_others_removed(void)
+{
+	TEST("find_plugin_after_rebuild - all others removed, only self remains");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	plugC->status = PL_EMPTY; plugC->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 0);
+	ASSERT_INT(count, 1);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 23: [A,B,C,D,E] idx=4(E), A,B,C removed → [D,E]. E at 1.
+static int test_find_after_rebuild_many_earlier_removed(void)
+{
+	TEST("find_plugin_after_rebuild - many earlier removed, large shift");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	memset(&fake_dllapi5, 0, sizeof(fake_dllapi5));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	MPlugin *plugD = &list->plist[3];
+	memset(plugD, 0, sizeof(*plugD)); plugD->index = 4;
+	plugD->status = PL_RUNNING; plugD->tables.dllapi = &fake_dllapi4;
+
+	MPlugin *plugE = &list->plist[4];
+	memset(plugE, 0, sizeof(*plugE)); plugE->index = 5;
+	plugE->status = PL_RUNNING; plugE->tables.dllapi = &fake_dllapi5;
+
+	list->endlist = 5;
+	list->rebuild_hook_lists();
+
+	plugA->status = PL_EMPTY; plugA->tables.dllapi = NULL;
+	plugB->status = PL_EMPTY; plugB->tables.dllapi = NULL;
+	plugC->status = PL_EMPTY; plugC->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugE, count, plugs);
+	ASSERT_INT(new_i, 1);
+	ASSERT_INT(count, 2);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 24: [A] idx=0(A), 3 plugins added before A → [X,Y,Z,A]. A at 3.
+static int test_find_after_rebuild_many_earlier_added(void)
+{
+	TEST("find_plugin_after_rebuild - many earlier added, large shift right");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+
+	// plist[0,1,2] empty, plist[3] = A
+	MPlugin *plugA = &list->plist[3];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 4;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	list->endlist = 4;
+	list->rebuild_hook_lists();
+
+	MPlugin *plugX = &list->plist[0];
+	memset(plugX, 0, sizeof(*plugX)); plugX->index = 1;
+	plugX->status = PL_RUNNING; plugX->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugY = &list->plist[1];
+	memset(plugY, 0, sizeof(*plugY)); plugY->index = 2;
+	plugY->status = PL_RUNNING; plugY->tables.dllapi = &fake_dllapi3;
+
+	MPlugin *plugZ = &list->plist[2];
+	memset(plugZ, 0, sizeof(*plugZ)); plugZ->index = 3;
+	plugZ->status = PL_RUNNING; plugZ->tables.dllapi = &fake_dllapi4;
+
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugA, count, plugs);
+	ASSERT_INT(new_i, 3);
+	ASSERT_INT(count, 4);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 25: [A,B,C] idx=1(B), no state change, rebuild → [A,B,C]. B stays at 1.
+static int test_find_after_rebuild_no_change(void)
+{
+	TEST("find_plugin_after_rebuild - rebuild with no change");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugB, count, plugs);
+	ASSERT_INT(new_i, 1);
+	ASSERT_INT(count, 3);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Case 26: [A,B,C] idx=2(C), self removed (last) → [A,B]. Return 1 so i++→2, loop ends.
+static int test_find_after_rebuild_self_removed_last(void)
+{
+	TEST("find_plugin_after_rebuild - self removed, was last");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	MPlugin *plugA = &list->plist[0];
+	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
+	plugA->status = PL_RUNNING; plugA->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plugB = &list->plist[1];
+	memset(plugB, 0, sizeof(*plugB)); plugB->index = 2;
+	plugB->status = PL_RUNNING; plugB->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plugC = &list->plist[2];
+	memset(plugC, 0, sizeof(*plugC)); plugC->index = 3;
+	plugC->status = PL_RUNNING; plugC->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	plugC->status = PL_EMPTY; plugC->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	int count;
+	MPlugin * const *plugs;
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, mFALSE, plugC, count, plugs);
+	// i=1, loop does i++ → 2, 2<2 false, loop ends. No plugins skipped.
+	ASSERT_INT(new_i, 1);
+	ASSERT_INT(count, 2);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// ============================================================
 // hook_list stability during iteration (issue #108)
 // ============================================================
 
 // Simulates the iteration pattern in main_hook_function:
 // cache plugs pointer and count, then iterate. Tests verify that
-// rebuild_hook_lists called mid-iteration causes problems with the
-// cached values.
-
-static DLL_FUNCTIONS fake_dllapi3;
+// rebuild_hook_lists called mid-iteration invalidates cached values,
+// which the fix in api_hook.cpp detects via hook_list_tables_updated.
 
 static int test_rebuild_during_iteration_load(void)
 {
@@ -4645,6 +5764,7 @@ static int test_rebuild_during_iteration_load(void)
 
 	// Simulate: during iteration at i=0, a new plugin is loaded
 	// (AMXX loads module via LOAD_PLUGIN from within hook callback)
+	hook_list_tables_updated = mFALSE;
 	MPlugin *plug2 = &list->plist[2];
 	memset(plug2, 0, sizeof(*plug2));
 	plug2->index = 3;
@@ -4653,13 +5773,16 @@ static int test_rebuild_during_iteration_load(void)
 	list->endlist = 3;
 	list->rebuild_hook_lists();
 
+	// rebuild_hook_lists signals that cached pointers are stale
+	ASSERT_TRUE(hook_list_tables_updated == mTRUE);
+
 	// After rebuild: the hook list has 3 entries now
 	ASSERT_INT(hlist->count, 3);
 
-	// BUG: cached 'count' is stale (still 2), new plugin won't be called
+	// Cached 'count' is stale (still 2) — fix must re-read from list
 	ASSERT_TRUE(count != hlist->count);
 
-	// BUG: cached 'plugs' pointer is dangling (realloc moved data)
+	// Cached 'plugs' pointer is dangling (realloc moved data)
 	ASSERT_TRUE(plugs != hlist->plugs);
 
 	teardown_globals();
@@ -4714,11 +5837,10 @@ static int test_rebuild_during_iteration_unload_later(void)
 	// After rebuild: only 2 plugins, plug0 and plug1 stay in positions 0,1
 	ASSERT_INT(hlist->count, 2);
 
-	// BUG: cached count is 3, loop would try to access plugs[2]
-	// which is now beyond valid data (use-after-free or garbage)
+	// Cached count is 3 but list now has 2 — fix must re-read
 	ASSERT_TRUE(count > hlist->count);
 
-	// BUG: cached plugs pointer is dangling
+	// Cached plugs pointer is dangling
 	ASSERT_TRUE(plugs != hlist->plugs);
 
 	teardown_globals();
@@ -4842,7 +5964,7 @@ static int test_rebuild_during_iteration_load_post(void)
 
 	ASSERT_INT(hlist->count, 3);
 
-	// BUG: cached count and plugs are stale
+	// Cached count and plugs are stale — fix must re-read
 	ASSERT_TRUE(count != hlist->count);
 	ASSERT_TRUE(plugs != hlist->plugs);
 
@@ -4955,7 +6077,7 @@ static int test_rebuild_during_iteration_segfault(void)
 	list->rebuild_hook_lists();
 
 	// Old 'plugs' is now freed+zeroed memory.
-	// Fork a child that dereferences it like main_hook_function would:
+	// Fork a child that dereferences it without the fix's protection:
 	//   plug = plugs[0];          // reads NULL from zeroed memory
 	//   table = plug->tables...;  // SIGSEGV
 	pid_t pid = fork();
@@ -4969,8 +6091,8 @@ static int test_rebuild_during_iteration_segfault(void)
 
 	int status = 0;
 	waitpid(pid, &status, 0);
-	ASSERT_TRUE(WIFSIGNALED(status));
-	ASSERT_TRUE(WTERMSIG(status) == SIGSEGV);
+	// SIGSEGV/SIGABRT normally; ASan may exit(1) instead of signaling
+	ASSERT_TRUE(WIFSIGNALED(status) || (WIFEXITED(status) && WEXITSTATUS(status) != 0));
 
 	teardown_globals();
 	PASS();
@@ -5198,6 +6320,34 @@ int main(void)
 	fail |= test_rebuild_plugs_contiguous();
 	fail |= test_rebuild_repeated_calls();
 	fail |= test_rebuild_endlist_bounds();
+
+	// find_plugin_after_rebuild (issue #108)
+	fail |= test_find_after_rebuild_later_removed();
+	fail |= test_find_after_rebuild_later_removed2();
+	fail |= test_find_after_rebuild_later_added();
+	fail |= test_find_after_rebuild_earlier_removed();
+	fail |= test_find_after_rebuild_earlier_paused();
+	fail |= test_find_after_rebuild_two_earlier_removed();
+	fail |= test_find_after_rebuild_earlier_removed_mid();
+	fail |= test_find_after_rebuild_earlier_removed_becomes_first();
+	fail |= test_find_after_rebuild_earlier_added();
+	fail |= test_find_after_rebuild_earlier_added_last();
+	fail |= test_find_after_rebuild_added_between();
+	fail |= test_find_after_rebuild_two_earlier_added();
+	fail |= test_find_after_rebuild_earlier_unpaused();
+	fail |= test_find_after_rebuild_self_removed_only();
+	fail |= test_find_after_rebuild_self_removed_first();
+	fail |= test_find_after_rebuild_self_removed_mid();
+	fail |= test_find_after_rebuild_self_paused_mid();
+	fail |= test_find_after_rebuild_mixed_remove_add_later();
+	fail |= test_find_after_rebuild_mixed_remove_add_earlier();
+	fail |= test_find_after_rebuild_mixed_last_net_zero();
+	fail |= test_find_after_rebuild_mixed_add_before_remove_after();
+	fail |= test_find_after_rebuild_others_removed();
+	fail |= test_find_after_rebuild_many_earlier_removed();
+	fail |= test_find_after_rebuild_many_earlier_added();
+	fail |= test_find_after_rebuild_no_change();
+	fail |= test_find_after_rebuild_self_removed_last();
 
 	// hook_list stability during iteration (issue #108)
 	fail |= test_rebuild_during_iteration_load();

--- a/metamod/tests/test_mlist.cpp
+++ b/metamod/tests/test_mlist.cpp
@@ -6,6 +6,9 @@
 #include <string.h>
 #include <utime.h>
 #include <time.h>
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 #include <extdll.h>
 
@@ -19,13 +22,25 @@
 #include "test_common.h"
 
 static bool force_realloc_fail = false;
+static size_t last_realloc_old_size = 0;
 
 extern "C" void *__real_realloc(void *ptr, size_t size);
 extern "C" void *__wrap_realloc(void *ptr, size_t size)
 {
 	if (force_realloc_fail)
 		return NULL;
-	return __real_realloc(ptr, size);
+	// Always move the allocation so tests can detect stale pointers.
+	void *newptr = malloc(size);
+	if (!newptr)
+		return NULL;
+	if (ptr) {
+		memcpy(newptr, ptr, size);
+		// Zero old memory to make use-after-free deterministic (NULL derefs).
+		memset(ptr, 0, last_realloc_old_size);
+		free(ptr);
+	}
+	last_realloc_old_size = size;
+	return newptr;
 }
 
 static MRegCmdList test_reg_cmds;
@@ -4583,6 +4598,386 @@ static int test_rebuild_endlist_bounds(void)
 }
 
 // ============================================================
+// hook_list stability during iteration (issue #108)
+// ============================================================
+
+// Simulates the iteration pattern in main_hook_function:
+// cache plugs pointer and count, then iterate. Tests verify that
+// rebuild_hook_lists called mid-iteration causes problems with the
+// cached values.
+
+static DLL_FUNCTIONS fake_dllapi3;
+
+static int test_rebuild_during_iteration_load(void)
+{
+	TEST("rebuild during iteration - load invalidates cached plugs");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	// Start with 2 running plugins
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->index = 1;
+	plug0->status = PL_RUNNING;
+	plug0->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->index = 2;
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+
+	// Simulate main_hook_function: cache plugs and count
+	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi);
+	int count = hlist->count;
+	MPlugin * const *plugs = hlist->plugs;
+
+	ASSERT_INT(count, 2);
+	ASSERT_PTR_EQ(plugs[0], plug0);
+	ASSERT_PTR_EQ(plugs[1], plug1);
+
+	// Simulate: during iteration at i=0, a new plugin is loaded
+	// (AMXX loads module via LOAD_PLUGIN from within hook callback)
+	MPlugin *plug2 = &list->plist[2];
+	memset(plug2, 0, sizeof(*plug2));
+	plug2->index = 3;
+	plug2->status = PL_RUNNING;
+	plug2->tables.dllapi = &fake_dllapi3;
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	// After rebuild: the hook list has 3 entries now
+	ASSERT_INT(hlist->count, 3);
+
+	// BUG: cached 'count' is stale (still 2), new plugin won't be called
+	ASSERT_TRUE(count != hlist->count);
+
+	// BUG: cached 'plugs' pointer is dangling (realloc moved data)
+	ASSERT_TRUE(plugs != hlist->plugs);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_during_iteration_unload_later(void)
+{
+	TEST("rebuild during iteration - unload later plugin shifts nothing");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	// 3 running plugins
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->index = 1;
+	plug0->status = PL_RUNNING;
+	plug0->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->index = 2;
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plug2 = &list->plist[2];
+	memset(plug2, 0, sizeof(*plug2));
+	plug2->index = 3;
+	plug2->status = PL_RUNNING;
+	plug2->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	// Cache like main_hook_function does
+	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi);
+	int count = hlist->count;
+	MPlugin * const *plugs = hlist->plugs;
+
+	ASSERT_INT(count, 3);
+
+	// Simulate: at i=0, plug2 (last one) is unloaded
+	plug2->status = PL_EMPTY;
+	plug2->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	// After rebuild: only 2 plugins, plug0 and plug1 stay in positions 0,1
+	ASSERT_INT(hlist->count, 2);
+
+	// BUG: cached count is 3, loop would try to access plugs[2]
+	// which is now beyond valid data (use-after-free or garbage)
+	ASSERT_TRUE(count > hlist->count);
+
+	// BUG: cached plugs pointer is dangling
+	ASSERT_TRUE(plugs != hlist->plugs);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_during_iteration_unload_earlier(void)
+{
+	TEST("rebuild during iteration - unload earlier plugin shifts indices");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	// 3 running plugins
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->index = 1;
+	plug0->status = PL_RUNNING;
+	plug0->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->index = 2;
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plug2 = &list->plist[2];
+	memset(plug2, 0, sizeof(*plug2));
+	plug2->index = 3;
+	plug2->status = PL_RUNNING;
+	plug2->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	// Cache like main_hook_function does
+	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi);
+	int count = hlist->count;
+	(void)count;
+
+	// Verify initial order
+	ASSERT_PTR_EQ(hlist->plugs[0], plug0);
+	ASSERT_PTR_EQ(hlist->plugs[1], plug1);
+	ASSERT_PTR_EQ(hlist->plugs[2], plug2);
+
+	// Simulate: while iterating at i=1 (calling plug1),
+	// plug0 (earlier plugin) gets unloaded
+	plug0->status = PL_EMPTY;
+	plug0->tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	// After rebuild: [plug1, plug2], count=2
+	ASSERT_INT(hlist->count, 2);
+	ASSERT_PTR_EQ(hlist->plugs[0], plug1);
+	ASSERT_PTR_EQ(hlist->plugs[1], plug2);
+
+	// BUG: if loop was at i=1 and continues to i=2 with old count=3,
+	// it accesses plugs[2] which is beyond the new list.
+	// Even with fixed arrays, if loop increments i to 2 and count is
+	// re-read as 2, loop ends — but plug2 (now at index 1) was SKIPPED.
+	// The iteration at i=1 already processed plug1 (now at index 0),
+	// so effectively plug2 never gets called.
+	//
+	// Correct behavior after fix: detect rebuild happened, find plug1
+	// in new list at index 0, set i=0, re-read count=2, continue from
+	// i=1 which is plug2.
+	ASSERT_TRUE(hlist->plugs[1] == plug2);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_during_iteration_load_post(void)
+{
+	TEST("rebuild during post iteration - load invalidates cached plugs");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	// 2 running plugins with post tables
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->index = 1;
+	plug0->status = PL_RUNNING;
+	plug0->post_tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->index = 2;
+	plug1->status = PL_RUNNING;
+	plug1->post_tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+
+	// Cache post hook list like main_hook_function does
+	const api_plugin_list_t *hlist = list->get_hook_post_list(e_api_dllapi);
+	int count = hlist->count;
+	MPlugin * const *plugs = hlist->plugs;
+
+	ASSERT_INT(count, 2);
+	ASSERT_PTR_EQ(plugs[0], plug0);
+	ASSERT_PTR_EQ(plugs[1], plug1);
+
+	// New plugin loaded during post hook callback
+	MPlugin *plug2 = &list->plist[2];
+	memset(plug2, 0, sizeof(*plug2));
+	plug2->index = 3;
+	plug2->status = PL_RUNNING;
+	plug2->post_tables.dllapi = &fake_dllapi3;
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	ASSERT_INT(hlist->count, 3);
+
+	// BUG: cached count and plugs are stale
+	ASSERT_TRUE(count != hlist->count);
+	ASSERT_TRUE(plugs != hlist->plugs);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_during_iteration_unload_earlier_post(void)
+{
+	TEST("rebuild during post iteration - unload earlier shifts indices");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	// 3 running plugins with post tables
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->index = 1;
+	plug0->status = PL_RUNNING;
+	plug0->post_tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->index = 2;
+	plug1->status = PL_RUNNING;
+	plug1->post_tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plug2 = &list->plist[2];
+	memset(plug2, 0, sizeof(*plug2));
+	plug2->index = 3;
+	plug2->status = PL_RUNNING;
+	plug2->post_tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	// Cache post hook list
+	const api_plugin_list_t *hlist = list->get_hook_post_list(e_api_dllapi);
+	int count = hlist->count;
+	(void)count;
+
+	ASSERT_PTR_EQ(hlist->plugs[0], plug0);
+	ASSERT_PTR_EQ(hlist->plugs[1], plug1);
+	ASSERT_PTR_EQ(hlist->plugs[2], plug2);
+
+	// Simulate: during post iteration at i=1, plug0 unloaded
+	plug0->status = PL_EMPTY;
+	plug0->post_tables.dllapi = NULL;
+	list->rebuild_hook_lists();
+
+	// After rebuild: [plug1, plug2], count=2
+	ASSERT_INT(hlist->count, 2);
+	ASSERT_PTR_EQ(hlist->plugs[0], plug1);
+	ASSERT_PTR_EQ(hlist->plugs[1], plug2);
+
+	// Same bug: plug2 at new index 1 would be skipped if loop
+	// continues from old i=1 -> i=2 which is beyond new count.
+	ASSERT_TRUE(hlist->plugs[1] == plug2);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+static int test_rebuild_during_iteration_segfault(void)
+{
+	TEST("rebuild during iteration - use-after-free segfaults");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+
+	// 2 running plugins
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->index = 1;
+	plug0->status = PL_RUNNING;
+	plug0->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->index = 2;
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+
+	// Simulate main_hook_function: cache plugs and count
+	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi);
+	int count = hlist->count;
+	MPlugin * const *plugs = hlist->plugs;
+
+	ASSERT_INT(count, 2);
+	ASSERT_PTR_EQ(plugs[0], plug0);
+
+	// A new plugin is loaded from within a hook callback → rebuild
+	MPlugin *plug2 = &list->plist[2];
+	memset(plug2, 0, sizeof(*plug2));
+	plug2->index = 3;
+	plug2->status = PL_RUNNING;
+	plug2->tables.dllapi = &fake_dllapi3;
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	// Old 'plugs' is now freed+zeroed memory.
+	// Fork a child that dereferences it like main_hook_function would:
+	//   plug = plugs[0];          // reads NULL from zeroed memory
+	//   table = plug->tables...;  // SIGSEGV
+	pid_t pid = fork();
+	if (pid == 0) {
+		// Child: simulate the crash path
+		volatile MPlugin *plug = plugs[0];
+		volatile void *table = plug->tables.dllapi;
+		(void)table;
+		_exit(0);
+	}
+
+	int status = 0;
+	waitpid(pid, &status, 0);
+	ASSERT_TRUE(WIFSIGNALED(status));
+	ASSERT_TRUE(WTERMSIG(status) == SIGSEGV);
+
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// ============================================================
 // main
 // ============================================================
 
@@ -4803,6 +5198,14 @@ int main(void)
 	fail |= test_rebuild_plugs_contiguous();
 	fail |= test_rebuild_repeated_calls();
 	fail |= test_rebuild_endlist_bounds();
+
+	// hook_list stability during iteration (issue #108)
+	fail |= test_rebuild_during_iteration_load();
+	fail |= test_rebuild_during_iteration_unload_later();
+	fail |= test_rebuild_during_iteration_unload_earlier();
+	fail |= test_rebuild_during_iteration_load_post();
+	fail |= test_rebuild_during_iteration_unload_earlier_post();
+	fail |= test_rebuild_during_iteration_segfault();
 
 	system("rm -rf /tmp/test_mlist_gd");
 


### PR DESCRIPTION
## Summary

- When a plugin callback triggers `rebuild_hook_lists()` (e.g. loading/unloading a plugin via AMXX), the cached `plugs` pointer and `count` in `main_hook_function` become stale because realloc moves the backing allocation, causing use-after-free crashes.
- Fix adds `hook_list_tables_updated` flag checked after each plugin call, with `MPluginList::find_plugin_after_rebuild()` using pointer comparison into `plist[]` to relocate the current plugin's index in the rebuilt list.
- Re-entrancy safe: uses `reentry_count` to track nesting depth. Only the outermost call clears the flag on entry/exit; inner calls capture it into a local `rebuild_happened` and propagate back on return, ensuring outer callers always detect rebuilds triggered during nested dispatch.
- Handles all edge cases: plugin added/removed/paused before/after current, self-removed, multiple simultaneous changes.

## Test plan

- [x] 26 unit tests for `find_plugin_after_rebuild` covering all combinations of load/unload/pause/unpause
- [x] 6 hook_list stability tests verifying stale pointer detection
- [x] 7 integration tests (`test_api_hook`) confirming no crash on real pre/post hook code paths
- [x] 5 re-entrancy tests verifying flag propagation across nested `main_hook_function` calls
- [x] Fork-based test confirming use-after-free crash without the fix (accepts SIGSEGV, SIGABRT, or ASan exit)
- [x] Full test suite passes: 169 mlist + 48 api_hook + all other test binaries
- [x] ASan/UBSan (`make sanitize`) passes clean
- [x] Tested on local rehlds server with amxmodx + jk_botti plugins

Closes #108