### PR TITLE
Preserve target endbr32 and atomically publish the dlsym linkent hook

### DIFF
--- a/metamod/osdep_linkent_linux.cpp
+++ b/metamod/osdep_linkent_linux.cpp
@@ -53,18 +53,25 @@
 //  -- by Jussi Kivilinna
 //
 
-// endbr32 (4 bytes) + jmp rel32 (5 bytes)
-#define ENDBR32_SIZE 4
+// jmp rel32 forwarder (5 bytes)
 #define JMP_INSN_SIZE 5
-#define BYTES_SIZE (ENDBR32_SIZE + JMP_INSN_SIZE)
+#define BYTES_SIZE JMP_INSN_SIZE
+
+// endbr32 landing pad size
+#define ENDBR32_SIZE 4
 
 typedef void * (*dlsym_func)(void * module, const char * funcname);
 
 static void * gamedll_module_handle = 0;
 static void * metamod_module_handle = 0;
 
-//pointer to original dlsym
+//pointer to original dlsym, used as the call target: it must stay the real
+//function entry so CET/IBT indirect calls land on its endbr32 landing pad.
 static dlsym_func dlsym_original;
+
+//address where the jmp forwarder is written: the entry past its endbr32 landing
+//pad (if any), so the endbr32 stays intact as a valid indirect-branch target.
+static unsigned char * dlsym_patch_addr;
 
 //contains jmp to replacement_dlsym @dlsym_original
 static unsigned char dlsym_new_bytes[BYTES_SIZE];
@@ -78,16 +85,53 @@ static pthread_mutex_t mutex_replacement_dlsym = PTHREAD_RECURSIVE_MUTEX_INITIAL
 // Tracks whether original dlsym bytes are currently restored (for re-entrant calls)
 static int is_original_restored = 0;
 
-//constructs endbr32 + jmp forwarder
+//constructs jmp forwarder
 inline void construct_jmp_instruction(void *x, void *place, void* target)
 {
 	unsigned char *p = (unsigned char *)x;
-	// endbr32: f3 0f 1e fb
-	p[0] = 0xf3; p[1] = 0x0f; p[2] = 0x1e; p[3] = 0xfb;
 	// jmp rel32 (offset relative to end of jmp instruction)
-	p[4] = 0xe9;
+	p[0] = 0xe9;
 	unsigned long rel = (unsigned long)target - ((unsigned long)place + BYTES_SIZE);
-	memcpy(p + 5, &rel, sizeof(rel));
+	memcpy(p + 1, &rel, sizeof(rel));
+}
+
+// endbr32 landing pad (f3 0f 1e fb): emitted at function entry under CET/IBT.
+inline bool has_endbr32(const void *p)
+{
+	static const unsigned char endbr32[ENDBR32_SIZE] = { 0xf3, 0x0f, 0x1e, 0xfb };
+	return memcmp(p, endbr32, ENDBR32_SIZE) == 0;
+}
+
+// Atomically publish `patch` (<= 8 bytes) over the 8-byte window at the dlsym
+// entry, preserving the untouched trailing bytes, so a concurrent caller never
+// observes a half-written jmp. The entry is 16-byte aligned in practice, so the
+// locked 8-byte store stays within one cache line.
+inline void DLLINTERNAL atomic_patch_dlsym(void *dst, const unsigned char *patch, size_t patchlen)
+{
+	unsigned long long want;
+
+	typedef char assert_bytes_fit[BYTES_SIZE <= (int)sizeof(want) ? 1 : -1];
+	(void)sizeof(assert_bytes_fit);
+
+	memcpy(&want, dst, sizeof(want));   // current 8 bytes
+	memcpy(&want, patch, patchlen);     // splice in the patch, keep the rest
+
+	unsigned int nlo = (unsigned int)want;
+	unsigned int nhi = (unsigned int)(want >> 32);
+
+	// lock cmpxchg8b store. EBX is saved/restored via xchg so this stays valid
+	// in PIC/PIE builds where EBX is the GOT pointer.
+	__asm__ __volatile__ (
+		"movl    (%%esi), %%eax\n\t"     // expected low  = *dst
+		"movl    4(%%esi), %%edx\n\t"    // expected high = *dst
+		"xchgl   %%ebx, %0\n\t"          // EBX <- new low (stash caller's EBX)
+		"1:\n\t"
+		"lock cmpxchg8b (%%esi)\n\t"
+		"jnz     1b\n\t"
+		"xchgl   %%ebx, %0\n\t"          // restore EBX
+		: "+r"(nlo)
+		: "S"(dst), "c"(nhi)
+		: "eax", "edx", "cc", "memory");
 }
 
 //checks if pointer x points to jump forwarder
@@ -110,7 +154,7 @@ inline void * extract_function_pointer_from_trampoline_jmp(void *x)
 inline void DLLINTERNAL restore_original_dlsym(void)
 {
 	//Copy old dlsym bytes back
-	memcpy((void*)dlsym_original, dlsym_old_bytes, BYTES_SIZE);
+	atomic_patch_dlsym(dlsym_patch_addr, dlsym_old_bytes, BYTES_SIZE);
 }
 
 //
@@ -119,7 +163,7 @@ inline void DLLINTERNAL restore_original_dlsym(void)
 inline void DLLINTERNAL reset_dlsym_hook(void)
 {
 	//Copy new dlsym bytes back
-	memcpy((void*)dlsym_original, dlsym_new_bytes, BYTES_SIZE);
+	atomic_patch_dlsym(dlsym_patch_addr, dlsym_new_bytes, BYTES_SIZE);
 }
 
 //
@@ -127,13 +171,15 @@ inline void DLLINTERNAL reset_dlsym_hook(void)
 //
 static FORCE_STACK_ALIGN void * __replacement_dlsym(void * module, const char * funcname)
 {
-	//these are needed in case dlsym calls dlsym, default one doesn't do
-	//it but some LD_PRELOADed library that hooks dlsym might actually
-	//do so.
-	int was_original_restored = is_original_restored;
+	int was_original_restored;
 
 	//Lock before modifing original dlsym
 	pthread_mutex_lock(&mutex_replacement_dlsym);
+
+	//these are needed in case dlsym calls dlsym, default one doesn't do
+	//it but some LD_PRELOADed library that hooks dlsym might actually
+	//do so.
+	was_original_restored = is_original_restored;
 
 	//restore old dlsym
 	if(!is_original_restored)
@@ -207,19 +253,28 @@ int DLLINTERNAL init_linkent_replacement(DLHANDLE MetamodHandle, DLHANDLE GameDl
 		sym_ptr = extract_function_pointer_from_trampoline_jmp(sym_ptr);
 	}
 
+	// Call target: keep the real entry so the indirect call through
+	// dlsym_original lands on its endbr32 under CET/IBT.
 	dlsym_original = (dlsym_func)sym_ptr;
 
+	// Patch site: write the jmp forwarder past the endbr32 landing pad (if
+	// present) so the entry's endbr32 stays intact as the branch target.
+	if(has_endbr32(sym_ptr))
+		sym_ptr = (char *)sym_ptr + ENDBR32_SIZE;
+	dlsym_patch_addr = (unsigned char *)sym_ptr;
+
 	//Backup old bytes of "dlsym" function
-	memcpy(dlsym_old_bytes, (void*)dlsym_original, BYTES_SIZE);
+	memcpy(dlsym_old_bytes, dlsym_patch_addr, BYTES_SIZE);
 
-	//Construct new bytes: "jmp offset[replacement_sendto] @ sendto_original"
-	construct_jmp_instruction((void*)&dlsym_new_bytes[0], (void*)dlsym_original, (void*)&__replacement_dlsym);
+	//Construct new bytes: "jmp offset[__replacement_dlsym] @ dlsym_patch_addr"
+	construct_jmp_instruction((void*)&dlsym_new_bytes[0], (void*)dlsym_patch_addr, (void*)&__replacement_dlsym);
 
-	//Check if bytes overlap page border.
-	unsigned long start_of_page = PAGE_ALIGN((long)dlsym_original) - PAGE_SIZE;
+	//Check if bytes overlap page border. The atomic publish writes an 8-byte
+	//window, so make the whole window writable (not just BYTES_SIZE).
+	unsigned long start_of_page = PAGE_ALIGN((long)dlsym_patch_addr) - PAGE_SIZE;
 	unsigned long size_of_pages = 0;
 
-	if((unsigned long)dlsym_original + BYTES_SIZE > PAGE_ALIGN((unsigned long)dlsym_original))
+	if((unsigned long)dlsym_patch_addr + sizeof(unsigned long long) > PAGE_ALIGN((unsigned long)dlsym_patch_addr))
 	{
 		//bytes are located on two pages
 		size_of_pages = PAGE_SIZE*2;

--- a/metamod/tests/test_osdep_linkent_linux.cpp
+++ b/metamod/tests/test_osdep_linkent_linux.cpp
@@ -35,7 +35,7 @@ static void restore_linkent(void)
 
 static int test_construct_jmp_basic(void)
 {
-	TEST("construct_jmp_instruction - endbr32 + jmp with correct offset");
+	TEST("construct_jmp_instruction - jmp with correct offset");
 	unsigned char buf[BYTES_SIZE];
 	memset(buf, 0, sizeof(buf));
 
@@ -45,16 +45,11 @@ static int test_construct_jmp_basic(void)
 
 	construct_jmp_instruction(buf, (void *)place_addr, (void *)target_addr);
 
-	// endbr32: f3 0f 1e fb
-	ASSERT_TRUE(buf[0] == 0xf3);
-	ASSERT_TRUE(buf[1] == 0x0f);
-	ASSERT_TRUE(buf[2] == 0x1e);
-	ASSERT_TRUE(buf[3] == 0xfb);
 	// jmp opcode
-	ASSERT_TRUE(buf[4] == 0xe9);
+	ASSERT_TRUE(buf[0] == 0xe9);
 
 	unsigned long encoded_offset;
-	memcpy(&encoded_offset, buf + 5, sizeof(encoded_offset));
+	memcpy(&encoded_offset, buf + 1, sizeof(encoded_offset));
 	unsigned long expected_offset = target_addr - (place_addr + BYTES_SIZE);
 	ASSERT_TRUE(encoded_offset == expected_offset);
 
@@ -74,12 +69,10 @@ static int test_construct_jmp_backward(void)
 
 	construct_jmp_instruction(buf, (void *)place_addr, (void *)target_addr);
 
-	ASSERT_TRUE(buf[0] == 0xf3);
-	ASSERT_TRUE(buf[3] == 0xfb);
-	ASSERT_TRUE(buf[4] == 0xe9);
+	ASSERT_TRUE(buf[0] == 0xe9);
 
 	unsigned long encoded_offset;
-	memcpy(&encoded_offset, buf + 5, sizeof(encoded_offset));
+	memcpy(&encoded_offset, buf + 1, sizeof(encoded_offset));
 	unsigned long expected_offset = target_addr - (place_addr + BYTES_SIZE);
 	ASSERT_TRUE(encoded_offset == expected_offset);
 
@@ -96,13 +89,23 @@ static int test_construct_jmp_self(void)
 	char fake_place[16];
 	construct_jmp_instruction(buf, fake_place, fake_place);
 
-	ASSERT_TRUE(buf[0] == 0xf3);
-	ASSERT_TRUE(buf[4] == 0xe9);
+	ASSERT_TRUE(buf[0] == 0xe9);
 
 	unsigned long encoded_offset;
-	memcpy(&encoded_offset, buf + 5, sizeof(encoded_offset));
+	memcpy(&encoded_offset, buf + 1, sizeof(encoded_offset));
 	ASSERT_TRUE(encoded_offset == (unsigned long)-(long)BYTES_SIZE);
 
+	PASS();
+	return 0;
+}
+
+static int test_has_endbr32(void)
+{
+	TEST("has_endbr32 - detects landing pad");
+	unsigned char with[]    = { 0xf3, 0x0f, 0x1e, 0xfb, 0x55 };
+	unsigned char without[] = { 0x55, 0x89, 0xe5, 0x00, 0x00 };
+	ASSERT_TRUE(has_endbr32(with) == true);
+	ASSERT_TRUE(has_endbr32(without) == false);
 	PASS();
 	return 0;
 }
@@ -205,6 +208,18 @@ static int test_linkent_init_and_hook(void)
 	int ret = init_linkent_replacement(mm_handle, gd_handle);
 	ASSERT_INT(ret, 1);
 
+	// The jmp forwarder is written at the patch site, not the call target.
+	ASSERT_INT(dlsym_patch_addr[0], 0xe9);
+	// The call target (dlsym_original) must stay the real entry so a CET/IBT
+	// indirect call lands on its endbr32; the forwarder sits past the endbr32.
+	unsigned char *entry = (unsigned char *)(void *)dlsym_original;
+	if (has_endbr32(entry)) {
+		ASSERT_INT(entry[0], 0xf3);
+		ASSERT_TRUE(dlsym_patch_addr == entry + ENDBR32_SIZE);
+	} else {
+		ASSERT_TRUE(dlsym_patch_addr == entry);
+	}
+
 	// After hook: dlsym on mm_handle should find GiveFnptrsToDll from gamedll
 	void *after = dlsym(mm_handle, "GiveFnptrsToDll");
 	ASSERT_PTR_NOT_NULL(after);
@@ -297,6 +312,7 @@ int main(void)
 	fail |= test_construct_jmp_basic();
 	fail |= test_construct_jmp_backward();
 	fail |= test_construct_jmp_self();
+	fail |= test_has_endbr32();
 	fail |= test_trampoline_ff25();
 	fail |= test_trampoline_not_ff25();
 	fail |= test_trampoline_only_ff();


### PR DESCRIPTION
Makes the Linux dynamic-linkent `dlsym` hook correct under CET/IBT and safe against a concurrent caller observing a partially written patch.

- Write only a 5-byte `jmp rel32` forwarder *past* the target's own endbr32 landing pad, instead of overwriting the entry with our own endbr32. The real entry keeps its endbr32, so an indirect branch to `dlsym` still lands on a valid endbr32.
- Split the call-through pointer from the patch site. `__replacement_dlsym` calls the real function through `dlsym_original`, so that pointer must stay the real entry (endbr32-valid indirect-call target); `dlsym_patch_addr` holds the endbr32-skipped address where bytes are backed up, patched and mprotected.
- Publish patches with `lock cmpxchg8b` over an 8-byte window (splice the patch in, preserve trailing bytes) so a concurrent caller never sees a half-written jmp; page-protection widened to that window.

The endbr32-skip and atomic-publish approach mirrors the equivalent change in jk_botti.

## Test plan
- `metamod/tests`: 851/851 pass, including `test_osdep_linkent_linux` (13/13). Added `has_endbr32` coverage and a white-box invariant in the hook integration test: when the entry has an endbr32, `dlsym_original` keeps it (`entry[0]==0xf3`) and `dlsym_patch_addr == entry + ENDBR32_SIZE`.
- Optimized `-fPIC` build links cleanly; verified in disassembly that the EBX/GOT save-restore around `cmpxchg8b` is correct whether GCC allocates the operand to `%edi` (real xchg) or `%ebx` (no-op xchg + GOT reload).
- Local rehlds server: loads metamod + gamedll, spawns crossfire entities (linkents resolve), clean exit — no #CP/segfault.
