### PR TITLE
Marshal API hook arguments in bulk on i386

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - name: Update package list for i386
@@ -21,6 +21,20 @@ jobs:
         run: CXX="i686-linux-gnu-g++" make -j4 -C metamod/tests run
       - name: Run valgrind
         run: CXX="i686-linux-gnu-g++" make -C metamod/tests valgrind
+      - name: Run tests optimized
+        run: CXX="i686-linux-gnu-g++" make -j4 -C metamod/tests run-opt
+
+  test-release-flags:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - name: Update package list for i386
+        run: sudo dpkg --add-architecture i386 && sudo apt-get -y update
+      - name: Install packages
+        run: sudo apt-get -y install build-essential g++-i686-linux-gnu libc6:i386 libstdc++6:i386 valgrind
+      - name: Run tests built with release flags
+        run: CXX="i686-linux-gnu-g++" make -j4 -C metamod/tests run-release
 
   sanitize:
     runs-on: ubuntu-24.04
@@ -36,7 +50,7 @@ jobs:
 
   clang-sanitize:
     runs-on: ubuntu-24.04
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       - name: Update package list for i386
@@ -47,6 +61,8 @@ jobs:
         run: CXX="clang++ -target i686-linux-gnu" make -j4 -C metamod/tests run
       - name: Run tests with clang ASan and UBSan
         run: CXX="clang++ -target i686-linux-gnu" make -j4 -C metamod/tests clang-sanitize
+      - name: Run tests with clang optimized
+        run: CXX="clang++ -target i686-linux-gnu" make -j4 -C metamod/tests run-opt
 
   coverage:
     runs-on: ubuntu-24.04
@@ -85,7 +101,7 @@ jobs:
     uses: ./.github/workflows/build.yml
 
   package:
-    needs: [test, sanitize, clang-sanitize, coverage, build]
+    needs: [test, test-release-flags, sanitize, clang-sanitize, coverage, build]
     uses: ./.github/workflows/package.yml
     with:
       version: snapshot

--- a/metamod/api_caller_list.h
+++ b/metamod/api_caller_list.h
@@ -1,0 +1,298 @@
+/*
+ * Copyright (c) 2026 Jussi Kivilinna
+ *
+ *    This file is part of "Metamod All-Mod-Support"-patch for Metamod.
+ *
+ *    Metamod is free software; you can redistribute it and/or modify it
+ *    under the terms of the GNU General Public License as published by the
+ *    Free Software Foundation; either version 2 of the License, or (at
+ *    your option) any later version.
+ *
+ *    Metamod is distributed in the hope that it will be useful, but
+ *    WITHOUT ANY WARRANTY; without even the implied warranty of
+ *    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *    General Public License for more details.
+ *
+ *    You should have received a copy of the GNU General Public License
+ *    along with Metamod; if not, write to the Free Software Foundation,
+ *    Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ *    In addition, as a special exception, the author gives permission to
+ *    link the code of this program with the Half-Life Game Engine ("HL
+ *    Engine") and Modified Game Libraries ("MODs") developed by Valve,
+ *    L.L.C ("Valve").  You must obey the GNU General Public License in all
+ *    respects for all of the code used other than the HL Engine and MODs
+ *    from Valve.  If you modify this file, you may extend this exception
+ *    to your version of the file, but you are not obligated to do so.  If
+ *    you do not wish to do so, delete this exception statement from your
+ *    version.
+ *
+ */
+
+//
+// One entry per (return type, argument pack) combination. No include guard
+// by design: the includer defines BEGIN_API_CALLER_FUNC and
+// END_API_CALLER_FUNC* first, and so decides what an entry expands to.
+// api_hook.cpp expands them into the real callers, test_api_hook.cpp a
+// second time into reference callers passing arguments one by one, so a
+// pack struct drifting from its call signature shows up as a differing
+// argument block instead of silent corruption.
+//
+
+//-
+BEGIN_API_CALLER_FUNC(void, ipV)
+END_API_CALLER_FUNC_void( (int, const void*, ...), (p->i1, p->p1, p->str) )
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2pV)
+END_API_CALLER_FUNC_void( (const void*, const void*, ...), (p->p1, p->p2, p->str) )
+
+//-
+BEGIN_API_CALLER_FUNC(void, void)
+END_API_CALLER_FUNC_noargs_void()
+
+BEGIN_API_CALLER_FUNC(ptr, void)
+END_API_CALLER_FUNC_noargs(void*)
+
+BEGIN_API_CALLER_FUNC(int, void)
+END_API_CALLER_FUNC_noargs(int)
+
+BEGIN_API_CALLER_FUNC(float, void)
+END_API_CALLER_FUNC_noargs(float)
+
+//-
+BEGIN_API_CALLER_FUNC(float, 2f)
+END_API_CALLER_FUNC( float, (float, float), (p->f1, p->f2) )
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2i)
+END_API_CALLER_FUNC_void( (int, int), (p->i1, p->i2) );
+
+BEGIN_API_CALLER_FUNC(int, 2i)
+END_API_CALLER_FUNC(int, (int, int), (p->i1, p->i2) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2i2p)
+END_API_CALLER_FUNC_void( (int, int, const void*, const void*), (p->i1, p->i2, p->p1, p->p2) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2i2pi2p)
+END_API_CALLER_FUNC_void( (int, int, const void*, const void*, int, const void*, const void*), (p->i1, p->i2, p->p1, p->p2, p->i3, p->p3, p->p4) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2p)
+END_API_CALLER_FUNC_void( (const void*, const void*), (p->p1, p->p2) );
+
+BEGIN_API_CALLER_FUNC(ptr, 2p)
+END_API_CALLER_FUNC(void*, (const void*, const void*), (p->p1, p->p2) );
+
+BEGIN_API_CALLER_FUNC(int, 2p)
+END_API_CALLER_FUNC(int, (const void*, const void*), (p->p1, p->p2) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2p2f)
+END_API_CALLER_FUNC_void( (const void*, const void*, float, float), (p->p1, p->p2, p->f1, p->f2) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2p2i2p)
+END_API_CALLER_FUNC_void( (const void*, const void*, int, int, const void*, const void*), (p->p1, p->p2, p->i1, p->i2, p->p3, p->p4) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2p3fus2uc)
+END_API_CALLER_FUNC_void( (const void*, const void*, float, float, float, unsigned short, unsigned char, unsigned char), (p->p1, p->p2, p->f1, p->f2, p->f3, p->us1, p->uc1, p->uc2) );
+
+//-
+BEGIN_API_CALLER_FUNC(ptr, 2pf)
+END_API_CALLER_FUNC(void*, (const void*, const void*, float), (p->p1, p->p2, p->f1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2pfi)
+END_API_CALLER_FUNC_void( (const void*, const void*, float, int), (p->p1, p->p2, p->f1, p->i1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2pi)
+END_API_CALLER_FUNC_void( (const void*, const void*, int), (p->p1, p->p2, p->i1) );
+
+BEGIN_API_CALLER_FUNC(int, 2pi)
+END_API_CALLER_FUNC(int, (const void*, const void*, int), (p->p1, p->p2, p->i1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2pui)
+END_API_CALLER_FUNC_void( (const void*, const void*, unsigned int), (p->p1, p->p2, p->ui1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2pi2p)
+END_API_CALLER_FUNC_void( (const void*, const void*, int, const void*, const void*), (p->p1, p->p2, p->i1, p->p3, p->p4) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 2pif2p)
+END_API_CALLER_FUNC_void( (const void*, const void*, int, float, const void*, const void*), (p->p1, p->p2, p->i1, p->f1, p->p3, p->p4) );
+
+//-
+BEGIN_API_CALLER_FUNC(int, 3i)
+END_API_CALLER_FUNC(int, (int, int, int), (p->i1, p->i2, p->i3) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 3p)
+END_API_CALLER_FUNC_void( (const void*, const void*, const void*), (p->p1, p->p2, p->p3) );
+
+BEGIN_API_CALLER_FUNC(ptr, 3p)
+END_API_CALLER_FUNC(void*, (const void*, const void*, const void*), (p->p1, p->p2, p->p3) );
+
+BEGIN_API_CALLER_FUNC(int, 3p)
+END_API_CALLER_FUNC(int, (const void*, const void*, const void*), (p->p1, p->p2, p->p3) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 3p2f2i)
+END_API_CALLER_FUNC_void( (const void*, const void*, const void*, float, float, int, int), (p->p1, p->p2, p->p3, p->f1, p->f2, p->i1, p->i2) );
+
+//-
+BEGIN_API_CALLER_FUNC(int, 3pi2p)
+END_API_CALLER_FUNC(int, (const void*, const void*, const void*, int, const void*, const void*), (p->p1, p->p2, p->p3, p->i1, p->p4, p->p5) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 4p)
+END_API_CALLER_FUNC_void( (const void*, const void*, const void*, const void*), (p->p1, p->p2, p->p3, p->p4) );
+
+BEGIN_API_CALLER_FUNC(int, 4p)
+END_API_CALLER_FUNC(int, (const void*, const void*, const void*, const void*), (p->p1, p->p2, p->p3, p->p4) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, 4pi)
+END_API_CALLER_FUNC_void( (const void*, const void*, const void*, const void*, int), (p->p1, p->p2, p->p3, p->p4, p->i1) );
+
+BEGIN_API_CALLER_FUNC(int, 4pi)
+END_API_CALLER_FUNC(int, (const void*, const void*, const void*, const void*, int), (p->p1, p->p2, p->p3, p->p4, p->i1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, f)
+END_API_CALLER_FUNC_void( (float), (p->f1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, i)
+END_API_CALLER_FUNC_void( (int), (p->i1) );
+
+BEGIN_API_CALLER_FUNC(int, i)
+END_API_CALLER_FUNC(int, (int), (p->i1) );
+
+BEGIN_API_CALLER_FUNC(ptr, i)
+END_API_CALLER_FUNC(void*, (int), (p->i1) );
+
+BEGIN_API_CALLER_FUNC(uint, ui)
+END_API_CALLER_FUNC(unsigned int, (unsigned int), (p->ui1) );
+
+BEGIN_API_CALLER_FUNC(ptr, ui)
+END_API_CALLER_FUNC(void*, (unsigned int), (p->ui1) );
+
+//-
+BEGIN_API_CALLER_FUNC(ulong, ul)
+END_API_CALLER_FUNC(unsigned long, (unsigned long), (p->ul1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, i2p)
+END_API_CALLER_FUNC_void( (int, const void*, const void*), (p->i1, p->p1, p->p2) );
+
+BEGIN_API_CALLER_FUNC(int, i2p)
+END_API_CALLER_FUNC(int, (int, const void*, const void*), (p->i1, p->p1, p->p2) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, i3p)
+END_API_CALLER_FUNC_void( (int, const void*, const void*, const void*), (p->i1, p->p1, p->p2, p->p3) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, ip)
+END_API_CALLER_FUNC_void( (int, const void*), (p->i1, p->p1) );
+
+BEGIN_API_CALLER_FUNC(ushort, ip)
+END_API_CALLER_FUNC( unsigned short, (int, const void*), (p->i1, p->p1) );
+
+BEGIN_API_CALLER_FUNC(int, ip)
+END_API_CALLER_FUNC( int, (int, const void*), (p->i1, p->p1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, ipusf2p2f4i)
+END_API_CALLER_FUNC_void( (int, const void*, unsigned short, float, const void*, const void*, float, float, int, int, int, int), (p->i1, p->p1, p->us1, p->f1, p->p2, p->p3, p->f2, p->f3, p->i2, p->i3, p->i4, p->i5) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, p)
+END_API_CALLER_FUNC_void( (const void*), (p->p1) );
+
+BEGIN_API_CALLER_FUNC(ptr, p)
+END_API_CALLER_FUNC(void*, (const void*), (p->p1) );
+
+BEGIN_API_CALLER_FUNC(char, p)
+END_API_CALLER_FUNC(char, (const void*), (p->p1) );
+
+BEGIN_API_CALLER_FUNC(int, p)
+END_API_CALLER_FUNC(int, (const void*), (p->p1) );
+
+BEGIN_API_CALLER_FUNC(uint, p)
+END_API_CALLER_FUNC(unsigned int, (const void*), (p->p1) );
+
+BEGIN_API_CALLER_FUNC(float, p)
+END_API_CALLER_FUNC(float, (const void*), (p->p1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, p2f)
+END_API_CALLER_FUNC_void( (const void*, float, float), (p->p1, p->f1, p->f2) );
+
+//-
+BEGIN_API_CALLER_FUNC(int, p2fi)
+END_API_CALLER_FUNC(int, (const void*, float, float, int), (p->p1, p->f1, p->f2, p->i1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, p2i)
+END_API_CALLER_FUNC_void( (const void*, int, int), (p->p1, p->i1, p->i2) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, p3i)
+END_API_CALLER_FUNC_void( (const void*, int, int, int), (p->p1, p->i1, p->i2, p->i3) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, p4i)
+END_API_CALLER_FUNC_void( (const void*, int, int, int, int), (p->p1, p->i1, p->i2, p->i3, p->i4) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, puc)
+END_API_CALLER_FUNC_void( (const void*, unsigned char), (p->p1, p->uc1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, pf)
+END_API_CALLER_FUNC_void( (const void*, float), (p->p1, p->f1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, pfp)
+END_API_CALLER_FUNC_void( (const void*, float, const void*), (p->p1, p->f1, p->p2) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, pi)
+END_API_CALLER_FUNC_void( (const void*, int), (p->p1, p->i1) );
+
+BEGIN_API_CALLER_FUNC(ptr, pi)
+END_API_CALLER_FUNC(void*, (const void*, int), (p->p1, p->i1) );
+
+BEGIN_API_CALLER_FUNC(int, pi)
+END_API_CALLER_FUNC(int, (const void*, int), (p->p1, p->i1) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, pi2p)
+END_API_CALLER_FUNC_void( (const void*, int, const void*, const void*), (p->p1, p->i1, p->p2, p->p3) );
+
+//-
+BEGIN_API_CALLER_FUNC(int, pi2p2ip)
+END_API_CALLER_FUNC(int, (const void*, int, const void*, const void*, int, int, const void*), (p->p1, p->i1, p->p2, p->p3, p->i2, p->i3, p->p4) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, pip)
+END_API_CALLER_FUNC_void( (const void*, int, const void*), (p->p1, p->i1, p->p2) );
+
+BEGIN_API_CALLER_FUNC(ptr, pip)
+END_API_CALLER_FUNC(void*, (const void*, int, const void*), (p->p1, p->i1, p->p2) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, pip2f2i)
+END_API_CALLER_FUNC_void( (const void*, int, const void*, float, float, int, int), (p->p1, p->i1, p->p2, p->f1, p->f2, p->i2, p->i3) );
+
+//-
+BEGIN_API_CALLER_FUNC(void, pip2f4i2p)
+END_API_CALLER_FUNC_void( (const void*, int, const void*, float, float, int, int, int, int, const void*, const void*), (p->p1, p->i1, p->p2, p->f1, p->f2, p->i2, p->i3, p->i4, p->i5, p->p3, p->p4) );

--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -450,274 +450,41 @@ HOT_FUNC void * DLLINTERNAL NOINLINE main_hook_function(const class_ret_t ret_in
 //
 #define BEGIN_API_CALLER_FUNC(ret_type, args_type_code) \
 	HOT_FUNC void * DLLINTERNAL _COMBINE4(api_caller_, ret_type, _args_, args_type_code)(const void * func, const void * packed_args) { \
-		_COMBINE2(pack_args_type_, args_type_code) * p ATTRIBUTE(unused)= (_COMBINE2(pack_args_type_, args_type_code) *)packed_args;
+		typedef _COMBINE2(pack_args_type_, args_type_code) pack_t; \
+		pack_t * p ATTRIBUTE(unused)= (pack_t *)packed_args;
+
+// Hand the packed struct over as one by-value block. The declared argument
+// list stays spelled out at each call site for the targets without it.
+#ifdef API_CALLER_BULK_ARGS
+	#define API_CALL_TARGET(ret_t, args_t, args) \
+		((*(( ret_t (*)(api_arg_blob<(int)sizeof(pack_t)>) )func)) \
+		 (*(const api_arg_blob<(int)sizeof(pack_t)> *)packed_args))
+#else
+	#define API_CALL_TARGET(ret_t, args_t, args) \
+		((*(( ret_t (*) args_t )func)) args)
+#endif
+
 #define END_API_CALLER_FUNC(ret_t, args_t, args) \
 		API_PAUSE_TSC_TRACKING(); \
-		return(*(void **)class_ret_t((*(( ret_t (*) args_t )func)) args).getptr()); \
+		return(*(void **)class_ret_t( API_CALL_TARGET(ret_t, args_t, args) ).getptr()); \
 	}
 #define END_API_CALLER_FUNC_void(args_t, args) \
 		API_PAUSE_TSC_TRACKING(); \
-		return((*(( void* (*) args_t )func)) args); \
+		return( API_CALL_TARGET(void*, args_t, args) ); \
+	}
+
+// Functions taking no arguments have no block to copy, and pack_args_type_void
+// is a 1-byte empty class rather than an argument image.
+#define END_API_CALLER_FUNC_noargs(ret_t) \
+		API_PAUSE_TSC_TRACKING(); \
+		return(*(void **)class_ret_t((*(( ret_t (*)(void) )func))()).getptr()); \
+	}
+#define END_API_CALLER_FUNC_noargs_void() \
+		API_PAUSE_TSC_TRACKING(); \
+		return((*(( void* (*)(void) )func))()); \
 	}
 
 //
 // API function callers.
 //
-
-//-
-BEGIN_API_CALLER_FUNC(void, ipV)
-END_API_CALLER_FUNC_void( (int, const void*, ...), (p->i1, p->p1, p->str) )
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2pV)
-END_API_CALLER_FUNC_void( (const void*, const void*, ...), (p->p1, p->p2, p->str) )
-
-//-
-BEGIN_API_CALLER_FUNC(void, void)
-END_API_CALLER_FUNC_void( (void), () )
-
-BEGIN_API_CALLER_FUNC(ptr, void)
-END_API_CALLER_FUNC(void*, (void), () )
-
-BEGIN_API_CALLER_FUNC(int, void)
-END_API_CALLER_FUNC(int, (void), () )
-
-BEGIN_API_CALLER_FUNC(float, void)
-END_API_CALLER_FUNC(float, (void), () )
-
-//-
-BEGIN_API_CALLER_FUNC(float, 2f)
-END_API_CALLER_FUNC( float, (float, float), (p->f1, p->f2) )
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2i)
-END_API_CALLER_FUNC_void( (int, int), (p->i1, p->i2) );
-
-BEGIN_API_CALLER_FUNC(int, 2i)
-END_API_CALLER_FUNC(int, (int, int), (p->i1, p->i2) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2i2p)
-END_API_CALLER_FUNC_void( (int, int, const void*, const void*), (p->i1, p->i2, p->p1, p->p2) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2i2pi2p)
-END_API_CALLER_FUNC_void( (int, int, const void*, const void*, int, const void*, const void*), (p->i1, p->i2, p->p1, p->p2, p->i3, p->p3, p->p4) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2p)
-END_API_CALLER_FUNC_void( (const void*, const void*), (p->p1, p->p2) );
-
-BEGIN_API_CALLER_FUNC(ptr, 2p)
-END_API_CALLER_FUNC(void*, (const void*, const void*), (p->p1, p->p2) );
-
-BEGIN_API_CALLER_FUNC(int, 2p)
-END_API_CALLER_FUNC(int, (const void*, const void*), (p->p1, p->p2) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2p2f)
-END_API_CALLER_FUNC_void( (const void*, const void*, float, float), (p->p1, p->p2, p->f1, p->f2) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2p2i2p)
-END_API_CALLER_FUNC_void( (const void*, const void*, int, int, const void*, const void*), (p->p1, p->p2, p->i1, p->i2, p->p3, p->p4) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2p3fus2uc)
-END_API_CALLER_FUNC_void( (const void*, const void*, float, float, float, unsigned short, unsigned char, unsigned char), (p->p1, p->p2, p->f1, p->f2, p->f3, p->us1, p->uc1, p->uc2) );
-
-//-
-BEGIN_API_CALLER_FUNC(ptr, 2pf)
-END_API_CALLER_FUNC(void*, (const void*, const void*, float), (p->p1, p->p2, p->f1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2pfi)
-END_API_CALLER_FUNC_void( (const void*, const void*, float, int), (p->p1, p->p2, p->f1, p->i1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2pi)
-END_API_CALLER_FUNC_void( (const void*, const void*, int), (p->p1, p->p2, p->i1) );
-
-BEGIN_API_CALLER_FUNC(int, 2pi)
-END_API_CALLER_FUNC(int, (const void*, const void*, int), (p->p1, p->p2, p->i1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2pui)
-END_API_CALLER_FUNC_void( (const void*, const void*, unsigned int), (p->p1, p->p2, p->ui1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2pi2p)
-END_API_CALLER_FUNC_void( (const void*, const void*, int, const void*, const void*), (p->p1, p->p2, p->i1, p->p3, p->p4) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 2pif2p)
-END_API_CALLER_FUNC_void( (const void*, const void*, int, float, const void*, const void*), (p->p1, p->p2, p->i1, p->f1, p->p3, p->p4) );
-
-//-
-BEGIN_API_CALLER_FUNC(int, 3i)
-END_API_CALLER_FUNC(int, (int, int, int), (p->i1, p->i2, p->i3) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 3p)
-END_API_CALLER_FUNC_void( (const void*, const void*, const void*), (p->p1, p->p2, p->p3) );
-
-BEGIN_API_CALLER_FUNC(ptr, 3p)
-END_API_CALLER_FUNC(void*, (const void*, const void*, const void*), (p->p1, p->p2, p->p3) );
-
-BEGIN_API_CALLER_FUNC(int, 3p)
-END_API_CALLER_FUNC(int, (const void*, const void*, const void*), (p->p1, p->p2, p->p3) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 3p2f2i)
-END_API_CALLER_FUNC_void( (const void*, const void*, const void*, float, float, int, int), (p->p1, p->p2, p->p3, p->f1, p->f2, p->i1, p->i2) );
-
-//-
-BEGIN_API_CALLER_FUNC(int, 3pi2p)
-END_API_CALLER_FUNC(int, (const void*, const void*, const void*, int, const void*, const void*), (p->p1, p->p2, p->p3, p->i1, p->p4, p->p5) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 4p)
-END_API_CALLER_FUNC_void( (const void*, const void*, const void*, const void*), (p->p1, p->p2, p->p3, p->p4) );
-
-BEGIN_API_CALLER_FUNC(int, 4p)
-END_API_CALLER_FUNC(int, (const void*, const void*, const void*, const void*), (p->p1, p->p2, p->p3, p->p4) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, 4pi)
-END_API_CALLER_FUNC_void( (const void*, const void*, const void*, const void*, int), (p->p1, p->p2, p->p3, p->p4, p->i1) );
-
-BEGIN_API_CALLER_FUNC(int, 4pi)
-END_API_CALLER_FUNC(int, (const void*, const void*, const void*, const void*, int), (p->p1, p->p2, p->p3, p->p4, p->i1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, f)
-END_API_CALLER_FUNC_void( (float), (p->f1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, i)
-END_API_CALLER_FUNC_void( (int), (p->i1) );
-
-BEGIN_API_CALLER_FUNC(int, i)
-END_API_CALLER_FUNC(int, (int), (p->i1) );
-
-BEGIN_API_CALLER_FUNC(ptr, i)
-END_API_CALLER_FUNC(void*, (int), (p->i1) );
-
-BEGIN_API_CALLER_FUNC(uint, ui)
-END_API_CALLER_FUNC(unsigned int, (unsigned int), (p->ui1) );
-
-BEGIN_API_CALLER_FUNC(ptr, ui)
-END_API_CALLER_FUNC(void*, (unsigned int), (p->ui1) );
-
-//-
-BEGIN_API_CALLER_FUNC(ulong, ul)
-END_API_CALLER_FUNC(unsigned long, (unsigned long), (p->ul1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, i2p)
-END_API_CALLER_FUNC_void( (int, const void*, const void*), (p->i1, p->p1, p->p2) );
-
-BEGIN_API_CALLER_FUNC(int, i2p)
-END_API_CALLER_FUNC(int, (int, const void*, const void*), (p->i1, p->p1, p->p2) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, i3p)
-END_API_CALLER_FUNC_void( (int, const void*, const void*, const void*), (p->i1, p->p1, p->p2, p->p3) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, ip)
-END_API_CALLER_FUNC_void( (int, const void*), (p->i1, p->p1) );
-
-BEGIN_API_CALLER_FUNC(ushort, ip)
-END_API_CALLER_FUNC( unsigned short, (int, const void*), (p->i1, p->p1) );
-
-BEGIN_API_CALLER_FUNC(int, ip)
-END_API_CALLER_FUNC( int, (int, const void*), (p->i1, p->p1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, ipusf2p2f4i)
-END_API_CALLER_FUNC_void( (int, const void*, unsigned short, float, const void*, const void*, float, float, int, int, int, int), (p->i1, p->p1, p->us1, p->f1, p->p2, p->p3, p->f2, p->f3, p->i2, p->i3, p->i4, p->i5) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, p)
-END_API_CALLER_FUNC_void( (const void*), (p->p1) );
-
-BEGIN_API_CALLER_FUNC(ptr, p)
-END_API_CALLER_FUNC(void*, (const void*), (p->p1) );
-
-BEGIN_API_CALLER_FUNC(char, p)
-END_API_CALLER_FUNC(char, (const void*), (p->p1) );
-
-BEGIN_API_CALLER_FUNC(int, p)
-END_API_CALLER_FUNC(int, (const void*), (p->p1) );
-
-BEGIN_API_CALLER_FUNC(uint, p)
-END_API_CALLER_FUNC(unsigned int, (const void*), (p->p1) );
-
-BEGIN_API_CALLER_FUNC(float, p)
-END_API_CALLER_FUNC(float, (const void*), (p->p1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, p2f)
-END_API_CALLER_FUNC_void( (const void*, float, float), (p->p1, p->f1, p->f2) );
-
-//-
-BEGIN_API_CALLER_FUNC(int, p2fi)
-END_API_CALLER_FUNC(int, (const void*, float, float, int), (p->p1, p->f1, p->f2, p->i1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, p2i)
-END_API_CALLER_FUNC_void( (const void*, int, int), (p->p1, p->i1, p->i2) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, p3i)
-END_API_CALLER_FUNC_void( (const void*, int, int, int), (p->p1, p->i1, p->i2, p->i3) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, p4i)
-END_API_CALLER_FUNC_void( (const void*, int, int, int, int), (p->p1, p->i1, p->i2, p->i3, p->i4) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, puc)
-END_API_CALLER_FUNC_void( (const void*, unsigned char), (p->p1, p->uc1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, pf)
-END_API_CALLER_FUNC_void( (const void*, float), (p->p1, p->f1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, pfp)
-END_API_CALLER_FUNC_void( (const void*, float, const void*), (p->p1, p->f1, p->p2) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, pi)
-END_API_CALLER_FUNC_void( (const void*, int), (p->p1, p->i1) );
-
-BEGIN_API_CALLER_FUNC(ptr, pi)
-END_API_CALLER_FUNC(void*, (const void*, int), (p->p1, p->i1) );
-
-BEGIN_API_CALLER_FUNC(int, pi)
-END_API_CALLER_FUNC(int, (const void*, int), (p->p1, p->i1) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, pi2p)
-END_API_CALLER_FUNC_void( (const void*, int, const void*, const void*), (p->p1, p->i1, p->p2, p->p3) );
-
-//-
-BEGIN_API_CALLER_FUNC(int, pi2p2ip)
-END_API_CALLER_FUNC(int, (const void*, int, const void*, const void*, int, int, const void*), (p->p1, p->i1, p->p2, p->p3, p->i2, p->i3, p->p4) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, pip)
-END_API_CALLER_FUNC_void( (const void*, int, const void*), (p->p1, p->i1, p->p2) );
-
-BEGIN_API_CALLER_FUNC(ptr, pip)
-END_API_CALLER_FUNC(void*, (const void*, int, const void*), (p->p1, p->i1, p->p2) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, pip2f2i)
-END_API_CALLER_FUNC_void( (const void*, int, const void*, float, float, int, int), (p->p1, p->i1, p->p2, p->f1, p->f2, p->i2, p->i3) );
-
-//-
-BEGIN_API_CALLER_FUNC(void, pip2f4i2p)
-END_API_CALLER_FUNC_void( (const void*, int, const void*, float, float, int, int, int, int, const void*, const void*), (p->p1, p->i1, p->p2, p->f1, p->f2, p->i2, p->i3, p->i4, p->i5, p->p3, p->p4) );
+#include "api_caller_list.h"

--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -233,9 +233,8 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 			META_WARNING("MRES_SUPERCEDE not valid in Post functions: %s:%s_Post()", plug->file, api_info.name);
 	}
 
-	if(unlikely(rebuild_happened))
-		hook_list_tables_updated = mTRUE;
-	if (likely(--reentry_index < 0)) {
+	hook_list_tables_updated = (mBOOL)(rebuild_happened | hook_list_tables_updated);
+	if(likely(--reentry_index < 0)) {
 		hook_list_tables_updated = mFALSE;
 	} else {
 		copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);
@@ -419,9 +418,8 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 		}
 	}
 
-	if(unlikely(rebuild_happened))
-		hook_list_tables_updated = mTRUE;
-	if (likely(--reentry_index < 0)) {
+	hook_list_tables_updated = (mBOOL)(rebuild_happened | hook_list_tables_updated);
+	if(likely(--reentry_index < 0)) {
 		hook_list_tables_updated = mFALSE;
 	} else {
 		copy_meta_globals(&PublicMetaGlobals, &saved_meta_globals);

--- a/metamod/api_hook.h
+++ b/metamod/api_hook.h
@@ -47,6 +47,18 @@ void DLLINTERNAL main_hook_function_void(unsigned int api_info_offset, enum_api_
 void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int api_info_offset, enum_api_t api, unsigned int func_offset, const void * packed_args);
 
 //
+// Every pack_args_type_* below is laid out as the image of the callee's
+// 4-byte argument slots, sub-word arguments widened to a full slot, so
+// passing one by value is the identical stack block and the compiler moves
+// it whole. Other targets classify by-value structs differently and pass
+// argument by argument. test_api_hook.cpp checks the layouts.
+//
+#if defined(__i386__) && defined(__GNUC__)
+	#define API_CALLER_BULK_ARGS 1
+	template<int N> struct api_arg_blob { char bytes[N]; };
+#endif
+
+//
 // API function args structures/classes
 //
 #define API_PACK_ARGS(type, args) \

--- a/metamod/api_hook.h
+++ b/metamod/api_hook.h
@@ -64,13 +64,41 @@ void * DLLINTERNAL main_hook_function(const class_ret_t ret_init, unsigned int a
 #define API_PACK_ARGS(type, args) \
 	_COMBINE2(pack_args_type_, type) packed_args args;
 
+#define API_BUILD_ARGS(type, args) API_PACK_ARGS(type, args)
+#define API_ARGS_PTR(type, args) ((const void *)&packed_args)
+
+//
+// A wrapper is entered through the block the engine or gamedll pushed,
+// which is already that image, so hand it over instead of copying the
+// parameters into a struct. Wrappers whose packed arguments are not simply
+// their own parameters keep packing.
+//
+// The block is taken as the address of the first parameter, which the ABI
+// does not promise: GCC leaves stack parameters where they arrived, but
+// clang copies out the one whose address is taken, and address sanitizer
+// gives each parameter its own redzoned slot. Both keep packing, as does
+// every non-i386 target. test_api_args.cpp checks the delivered block.
+//
+// META_WRAPPER_ARGS_PACKED forces packing, for the tests' reference build.
+#if defined(API_CALLER_BULK_ARGS) && !defined(META_WRAPPER_ARGS_PACKED) \
+	&& !defined(__clang__) && !defined(__SANITIZE_ADDRESS__)
+	#define API_WRAPPER_BULK_ARGS 1
+	#define API_ARGS_FIRST(first, rest...) first
+	#undef API_BUILD_ARGS
+	#undef API_ARGS_PTR
+	#define API_BUILD_ARGS(type, args)
+	#define API_ARGS_PTR(type, args) ((const void *)&(API_ARGS_FIRST args))
+#endif
+
 #define PACK_ARGS_CLASS_HEADER(type, constructor_args) \
 	class _COMBINE2(pack_args_type_, type) : public class_metamod_new { \
 		public: inline _COMBINE2(pack_args_type_, type) constructor_args
 
 #define PACK_ARGS_END };
 
-#define VOID_ARG 0
+// Addressable so a wrapper taking no arguments takes the same
+// &first-argument form; the void-argument callers never read through it.
+static const int VOID_ARG ATTRIBUTE(unused) = 0;
 
 PACK_ARGS_CLASS_HEADER(void, (int)) {};
 PACK_ARGS_END

--- a/metamod/dllapi.cpp
+++ b/metamod/dllapi.cpp
@@ -49,29 +49,29 @@
 // Original DLL routines, functions returning "void".
 #define META_DLLAPI_HANDLE_void(FN_TYPE, pfnName, pack_args_type, pfn_args) \
 	API_START_TSC_TRACKING(); \
-	API_PACK_ARGS(pack_args_type, pfn_args); \
-	main_hook_function_void(offsetof(dllapi_info_t, pfnName), e_api_dllapi, offsetof(DLL_FUNCTIONS, pfnName), &packed_args); \
+	API_BUILD_ARGS(pack_args_type, pfn_args); \
+	main_hook_function_void(offsetof(dllapi_info_t, pfnName), e_api_dllapi, offsetof(DLL_FUNCTIONS, pfnName), API_ARGS_PTR(pack_args_type, pfn_args)); \
 	API_END_TSC_TRACKING()
 
 // Original DLL routines, functions returning an actual value.
 #define META_DLLAPI_HANDLE(ret_t, ret_init, FN_TYPE, pfnName, pack_args_type, pfn_args) \
 	API_START_TSC_TRACKING(); \
-	API_PACK_ARGS(pack_args_type, pfn_args); \
-	class_ret_t ret_val(main_hook_function(class_ret_t((ret_t)ret_init), offsetof(dllapi_info_t, pfnName), e_api_dllapi, offsetof(DLL_FUNCTIONS, pfnName), &packed_args)); \
+	API_BUILD_ARGS(pack_args_type, pfn_args); \
+	class_ret_t ret_val(main_hook_function(class_ret_t((ret_t)ret_init), offsetof(dllapi_info_t, pfnName), e_api_dllapi, offsetof(DLL_FUNCTIONS, pfnName), API_ARGS_PTR(pack_args_type, pfn_args))); \
 	API_END_TSC_TRACKING()
 
 // The "new" api routines (just 3 right now), functions returning "void".
 #define META_NEWAPI_HANDLE_void(FN_TYPE, pfnName, pack_args_type, pfn_args) \
 	API_START_TSC_TRACKING(); \
-	API_PACK_ARGS(pack_args_type, pfn_args); \
-	main_hook_function_void(offsetof(newapi_info_t, pfnName), e_api_newapi, offsetof(NEW_DLL_FUNCTIONS, pfnName), &packed_args); \
+	API_BUILD_ARGS(pack_args_type, pfn_args); \
+	main_hook_function_void(offsetof(newapi_info_t, pfnName), e_api_newapi, offsetof(NEW_DLL_FUNCTIONS, pfnName), API_ARGS_PTR(pack_args_type, pfn_args)); \
 	API_END_TSC_TRACKING()
 
 // The "new" api routines (just 3 right now), functions returning an actual value.
 #define META_NEWAPI_HANDLE(ret_t, ret_init, FN_TYPE, pfnName, pack_args_type, pfn_args) \
 	API_START_TSC_TRACKING(); \
-	API_PACK_ARGS(pack_args_type, pfn_args); \
-	class_ret_t ret_val(main_hook_function(class_ret_t((ret_t)ret_init), offsetof(newapi_info_t, pfnName), e_api_newapi, offsetof(NEW_DLL_FUNCTIONS, pfnName), &packed_args)); \
+	API_BUILD_ARGS(pack_args_type, pfn_args); \
+	class_ret_t ret_val(main_hook_function(class_ret_t((ret_t)ret_init), offsetof(newapi_info_t, pfnName), e_api_newapi, offsetof(NEW_DLL_FUNCTIONS, pfnName), API_ARGS_PTR(pack_args_type, pfn_args))); \
 	API_END_TSC_TRACKING()
 
 

--- a/metamod/engine_api.cpp
+++ b/metamod/engine_api.cpp
@@ -52,15 +52,22 @@
 // Engine routines, functions returning "void".
 #define META_ENGINE_HANDLE_void(FN_TYPE, pfnName, pack_args_type, pfn_args) \
 	API_START_TSC_TRACKING(); \
-	API_PACK_ARGS(pack_args_type, pfn_args); \
-	main_hook_function_void(offsetof(engine_info_t, pfnName), e_api_engine, offsetof(enginefuncs_t, pfnName), &packed_args); \
+	API_BUILD_ARGS(pack_args_type, pfn_args); \
+	main_hook_function_void(offsetof(engine_info_t, pfnName), e_api_engine, offsetof(enginefuncs_t, pfnName), API_ARGS_PTR(pack_args_type, pfn_args)); \
 	API_END_TSC_TRACKING()
 
 // Engine routines, functions returning an actual value.
 #define META_ENGINE_HANDLE(ret_t, ret_init, FN_TYPE, pfnName, pack_args_type, pfn_args) \
 	API_START_TSC_TRACKING(); \
+	API_BUILD_ARGS(pack_args_type, pfn_args); \
+	class_ret_t ret_val(main_hook_function(class_ret_t((ret_t)ret_init), offsetof(engine_info_t, pfnName), e_api_engine, offsetof(enginefuncs_t, pfnName), API_ARGS_PTR(pack_args_type, pfn_args))); \
+	API_END_TSC_TRACKING()
+
+// Wrappers whose incoming slots cannot be handed over as they stand.
+#define META_ENGINE_HANDLE_void_packed(FN_TYPE, pfnName, pack_args_type, pfn_args) \
+	API_START_TSC_TRACKING(); \
 	API_PACK_ARGS(pack_args_type, pfn_args); \
-	class_ret_t ret_val(main_hook_function(class_ret_t((ret_t)ret_init), offsetof(engine_info_t, pfnName), e_api_engine, offsetof(enginefuncs_t, pfnName), &packed_args)); \
+	main_hook_function_void(offsetof(engine_info_t, pfnName), e_api_engine, offsetof(enginefuncs_t, pfnName), &packed_args); \
 	API_END_TSC_TRACKING()
 
 // For varargs functions
@@ -556,7 +563,7 @@ static HOT_FUNC FORCE_STACK_ALIGN void mm_CRC32_ProcessBuffer(CRC32_t *pulCRC, v
 	RETURN_API_void()
 }
 static HOT_FUNC FORCE_STACK_ALIGN void mm_CRC32_ProcessByte(CRC32_t *pulCRC, unsigned char ch) {
-	META_ENGINE_HANDLE_void(FN_CRC32_PROCESSBYTE, pfnCRC32_ProcessByte, puc, (pulCRC, ch));
+	META_ENGINE_HANDLE_void_packed(FN_CRC32_PROCESSBYTE, pfnCRC32_ProcessByte, puc, (pulCRC, ch));
 	RETURN_API_void()
 }
 static HOT_FUNC FORCE_STACK_ALIGN CRC32_t mm_CRC32_Final(CRC32_t pulCRC) {
@@ -633,7 +640,7 @@ static HOT_FUNC FORCE_STACK_ALIGN edict_t * mm_CreateFakeClient(const char *netn
 	RETURN_API(edict_t *)
 }
 static HOT_FUNC FORCE_STACK_ALIGN void mm_RunPlayerMove(edict_t *fakeclient, const float *viewangles, float forwardmove, float sidemove, float upmove, unsigned short buttons, byte impulse, byte msec ) {
-	META_ENGINE_HANDLE_void(FN_RUNPLAYERMOVE, pfnRunPlayerMove, 2p3fus2uc, (fakeclient, viewangles, forwardmove, sidemove, upmove, buttons, impulse, msec));
+	META_ENGINE_HANDLE_void_packed(FN_RUNPLAYERMOVE, pfnRunPlayerMove, 2p3fus2uc, (fakeclient, viewangles, forwardmove, sidemove, upmove, buttons, impulse, msec));
 	RETURN_API_void()
 }
 static HOT_FUNC FORCE_STACK_ALIGN int mm_NumberOfEntities(void) {
@@ -717,7 +724,7 @@ static HOT_FUNC FORCE_STACK_ALIGN unsigned short mm_PrecacheEvent( int type, con
 	RETURN_API(unsigned short)
 }
 static HOT_FUNC FORCE_STACK_ALIGN void mm_PlaybackEvent( int flags, const edict_t *pInvoker, unsigned short eventindex, float delay, float *origin, float *angles, float fparam1, float fparam2, int iparam1, int iparam2, int bparam1, int bparam2 ) {
-	META_ENGINE_HANDLE_void(FN_PLAYBACKEVENT, pfnPlaybackEvent, ipusf2p2f4i, (flags, pInvoker, eventindex, delay, origin, angles, fparam1, fparam2, iparam1, iparam2, bparam1, bparam2));
+	META_ENGINE_HANDLE_void_packed(FN_PLAYBACKEVENT, pfnPlaybackEvent, ipusf2p2f4i, (flags, pInvoker, eventindex, delay, origin, angles, fparam1, fparam2, iparam1, iparam2, bparam1, bparam2));
 	RETURN_API_void()
 }
 

--- a/metamod/game_autodetect.cpp
+++ b/metamod/game_autodetect.cpp
@@ -45,8 +45,10 @@
 const char * DLLINTERNAL autodetect_gamedll(const gamedll_t *gamedll, const char *knownfn)
 {
 	static char buf[256];
-	char dllpath[256];
-	char fnpath[256];
+	// full_gamedir_path resolves through realpath, which writes up to
+	// PATH_MAX regardless of what the caller has room for.
+	char dllpath[PATH_MAX];
+	char fnpath[PATH_MAX];
 	DIR *dir;
 	struct dirent *ent;
 	unsigned int fn_len;

--- a/metamod/mlist.h
+++ b/metamod/mlist.h
@@ -95,7 +95,9 @@ class MPluginList : public class_metamod_new {
 
 	// constructor/destructor:
 		MPluginList(const char *ifile) DLLINTERNAL;
-		~MPluginList(void) DLLINTERNAL;
+		// Not DLLINTERNAL: __cxa_atexit calls a static object's destructor
+		// as plain cdecl, where regparm would look for `this` in a register.
+		~MPluginList(void);
 
 	// functions:
 		void DLLINTERNAL reset_plugin(MPlugin *pl_find);

--- a/metamod/mplayer.h
+++ b/metamod/mplayer.h
@@ -63,7 +63,9 @@ public:
 
 public:
 	MPlayer() DLLINTERNAL;
-	~MPlayer() DLLINTERNAL;
+	// Not DLLINTERNAL, for the reason on ~MPluginList: regparm cannot
+	// survive a destructor reached through __cxa_atexit.
+	~MPlayer();
 	void        DLLINTERNAL set_cvar_query(const char *cvar);            // mark this player as querying a client cvar
 	void        DLLINTERNAL clear_cvar_query(const char *cvar=NULL);     // unmark this player as querying a client cvar
 	const char *DLLINTERNAL is_querying_cvar(void);                      // check if a player is querying a cvar. returns

--- a/metamod/tests/.gitignore
+++ b/metamod/tests/.gitignore
@@ -25,6 +25,7 @@ test_commands_meta
 test_dllapi
 test_engine_api
 test_api_args
+bench_api_hook
 test_h_export
 test_linkgame
 test_linkplug

--- a/metamod/tests/.gitignore
+++ b/metamod/tests/.gitignore
@@ -24,6 +24,7 @@ test_api_info
 test_commands_meta
 test_dllapi
 test_engine_api
+test_api_args
 test_h_export
 test_linkgame
 test_linkplug

--- a/metamod/tests/Makefile
+++ b/metamod/tests/Makefile
@@ -213,12 +213,30 @@ ALL_TESTS = test_support_meta test_osdep test_log_meta test_vdate \
     test_metamod_gamedll \
     test_osdep_detect_gamedll_win32 test_osdep_linkent_win32
 
-.PHONY: all run valgrind sanitize clang-sanitize coverage coverage-clean clean
+.PHONY: all run run-opt run-release valgrind sanitize clang-sanitize coverage coverage-clean clean
 
 all: $(ALL_TESTS)
 
 run: $(ALL_TESTS)
 	@for t in $(ALL_TESTS); do ./$$t || exit 1; done
+
+# The shipped build is optimized. Argument marshalling that folds away only
+# once the optimizer can see through a copy is invisible at the default -O0,
+# so the suite is also worth running the way the release is built.
+run-opt:
+	$(MAKE) clean
+	$(MAKE) CXXFLAGS="-O2" run
+
+# metamod.so is built with different code generation and a different calling
+# convention than the tests default to: PIC, regparm, no frame pointer. Which
+# prologue a wrapper gets, and where its arguments live, follow from those, so
+# argument marshalling can be right in one build and wrong in the other.
+RELEASE_FLAGS = -O2 -fomit-frame-pointer -flto=auto -fPIC -fvisibility=hidden \
+    -mtune=generic -fno-exceptions -fno-rtti -D__INTERNALS_USE_REGPARAMS__
+
+run-release:
+	$(MAKE) clean
+	$(MAKE) CXXFLAGS="$(RELEASE_FLAGS)" run
 
 VALGRIND = valgrind --leak-check=full --error-exitcode=1
 

--- a/metamod/tests/Makefile
+++ b/metamod/tests/Makefile
@@ -95,6 +95,26 @@ test_dllapi: test_dllapi.o $(EXTENDED_OBJS) dllapi.o api_hook.o api_info.o comma
 test_engine_api: test_engine_api.o $(EXTENDED_OBJS) engine_api.o api_hook.o api_info.o
 	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
+# Reference copies of the hook wrappers, built with the argument copy forced
+# back on and their entry points renamed, so test_api_args can compare the
+# argument block each pair of wrappers delivers.
+REFARGS_FLAGS = -DMETA_WRAPPER_ARGS_PACKED \
+    -DGetEntityAPI=ref_GetEntityAPI -DGetEntityAPI2=ref_GetEntityAPI2 \
+    -DGetNewDLLFunctions=ref_GetNewDLLFunctions \
+    -Dg_pHookedDllFunctions=ref_g_pHookedDllFunctions \
+    -Dg_pHookedNewDllFunctions=ref_g_pHookedNewDllFunctions \
+    -Dmeta_engfuncs=ref_meta_engfuncs
+
+dllapi_refargs.o: ../dllapi.cpp
+	${CXX} ${TEST_CXXFLAGS} $(REFARGS_FLAGS) -c $< -o $@
+
+engine_api_refargs.o: ../engine_api.cpp
+	${CXX} ${TEST_CXXFLAGS} $(REFARGS_FLAGS) -c $< -o $@
+
+test_api_args: test_api_args.o $(EXTENDED_OBJS) dllapi.o engine_api.o \
+    dllapi_refargs.o engine_api_refargs.o api_info.o commands_meta.o vdate.o
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
+
 test_h_export: test_h_export.o $(COMMON_OBJS) meta_eiface.o h_export.o \
     engineinfo.o osdep_p.o engine_test.so
 	${CXX} $(EXTRA_FLAGS) -o $@ $(filter %.o,$^) -ldl
@@ -184,7 +204,7 @@ ALL_TESTS = test_support_meta test_osdep test_log_meta test_vdate \
     test_mreg test_mreg_malloc test_mplayer test_conf_meta \
     test_game_support test_game_autodetect test_engineinfo \
     test_sdk_util test_api_hook test_api_info \
-    test_commands_meta test_dllapi test_engine_api \
+    test_commands_meta test_dllapi test_engine_api test_api_args \
     test_h_export test_linkgame test_linkplug \
     test_meta_eiface test_metamod test_mlist test_mplugin \
     test_mutil test_reg_support test_studioapi \

--- a/metamod/tests/Makefile
+++ b/metamod/tests/Makefile
@@ -213,7 +213,7 @@ ALL_TESTS = test_support_meta test_osdep test_log_meta test_vdate \
     test_metamod_gamedll \
     test_osdep_detect_gamedll_win32 test_osdep_linkent_win32
 
-.PHONY: all run run-opt run-release valgrind sanitize clang-sanitize coverage coverage-clean clean
+.PHONY: all run run-opt run-release bench valgrind sanitize clang-sanitize coverage coverage-clean clean
 
 all: $(ALL_TESTS)
 
@@ -237,6 +237,20 @@ RELEASE_FLAGS = -O2 -fomit-frame-pointer -flto=auto -fPIC -fvisibility=hidden \
 run-release:
 	$(MAKE) clean
 	$(MAKE) CXXFLAGS="$(RELEASE_FLAGS)" run
+
+# Dispatch cost of the API wrappers, with trivial plugin and gamedll callees
+# so what is measured is metamod's own overhead. A live server buries that
+# under the ~97% of cycles it spends elsewhere, which is enough to hide a
+# regression: pin it to a core and compare against a build of the base branch.
+# Built the way metamod.so is: measuring -O0 code would say nothing.
+bench:
+	$(MAKE) clean
+	$(MAKE) CXXFLAGS="$(RELEASE_FLAGS)" bench_api_hook
+	taskset -c 8 ./bench_api_hook
+
+bench_api_hook: bench_api_hook.o $(EXTENDED_OBJS) api_hook.o api_info.o \
+    dllapi.o engine_api.o commands_meta.o vdate.o mutil.o
+	${CXX} $(EXTRA_FLAGS) -o $@ $^ -ldl
 
 VALGRIND = valgrind --leak-check=full --error-exitcode=1
 

--- a/metamod/tests/bench_api_hook.cpp
+++ b/metamod/tests/bench_api_hook.cpp
@@ -1,0 +1,192 @@
+//
+// metamod-p - dispatch cost microbenchmark
+//
+// Drives real API wrappers in a fixed-iteration loop: wrapper ->
+// main_hook_function -> one hooked plugin -> gamedll/engine, with trivial
+// callees so what is left is metamod's own dispatch and argument
+// marshalling. A live server buries that under ~97% unrelated cycles.
+//
+// Reports TSC ticks per call, minimum of several repetitions so an
+// interrupt lands in the discarded runs rather than the reported one.
+//
+
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stddef.h>
+
+#include <extdll.h>
+
+#include "metamod.h"
+#include "dllapi.h"
+#include "engine_api.h"
+#include "api_info.h"
+#include "api_hook.h"
+#include "meta_api.h"
+#include "meta_eiface.h"
+#include "mlist.h"
+#include "mreg.h"
+#include "mplugin.h"
+#include "conf_meta.h"
+
+#include "engine_mock.h"
+
+meta_globals_t *gpMetaGlobals = &PublicMetaGlobals;
+
+static MPluginList &bench_plugins = *new MPluginList("plugins.ini");
+static MRegCmdList bench_cmds;
+static MRegCvarList bench_cvars;
+static MRegMsgList bench_msgs;
+static MConfig bench_config;
+static option_t bench_options[] = { { NULL, CF_NONE, NULL, NULL } };
+
+static DLL_FUNCTIONS gamedll_table;
+static DLL_FUNCTIONS plugin_pre_table;
+static enginefuncs_t engine_table;
+static enginefuncs_t *engine_table_ptr = &engine_table;
+
+// ---------------------------------------------------------------
+// Callees. Empty, but not inlinable: what is being timed is the cost of
+// reaching them, and each must set meta_result or dispatch warns.
+// ---------------------------------------------------------------
+
+static NOINLINE void plug_void_p(edict_t *) { PublicMetaGlobals.mres = MRES_IGNORED; }
+static NOINLINE void plug_void_2p(edict_t *, edict_t *) { PublicMetaGlobals.mres = MRES_IGNORED; }
+static NOINLINE void plug_void_p2i(edict_t *, int, int) { PublicMetaGlobals.mres = MRES_IGNORED; }
+static NOINLINE void plug_void_4pi(SAVERESTOREDATA *, const char *, void *, TYPEDESCRIPTION *, int)
+	{ PublicMetaGlobals.mres = MRES_IGNORED; }
+
+static NOINLINE void dll_void_p(edict_t *) {}
+static NOINLINE void dll_void_2p(edict_t *, edict_t *) {}
+static NOINLINE void dll_void_p2i(edict_t *, int, int) {}
+static NOINLINE void dll_void_4pi(SAVERESTOREDATA *, const char *, void *, TYPEDESCRIPTION *, int) {}
+
+static NOINLINE void eng_runplayermove(edict_t *, const float *, float, float, float,
+				       unsigned short, byte, byte) {}
+static NOINLINE void eng_playbackevent(int, const edict_t *, unsigned short, float, float *,
+				       float *, float, float, int, int, int, int) {}
+static NOINLINE void eng_setmodel(edict_t *, const char *) {}
+
+// ---------------------------------------------------------------
+// Timing
+// ---------------------------------------------------------------
+
+static inline unsigned long long rdtsc_now(void)
+{
+	unsigned int lo, hi;
+	__asm__ __volatile__ ("lfence\n\trdtsc" : "=a"(lo), "=d"(hi) :: "memory");
+	return ((unsigned long long)hi << 32) | lo;
+}
+
+#define ITERS 200000
+#define REPS  15
+
+// Each case is a block that calls the wrapper ITERS times; the wrapper is
+// reached through a volatile pointer so the call cannot be devirtualized
+// or hoisted.
+#define BENCH(name, decl_fn, setup, call) do { \
+	double best = 0; \
+	for (int rep = 0; rep < REPS; rep++) { \
+		setup; \
+		unsigned long long t0 = rdtsc_now(); \
+		for (int i = 0; i < ITERS; i++) { call; } \
+		unsigned long long t1 = rdtsc_now(); \
+		double per = (double)(t1 - t0) / ITERS; \
+		if (rep == 0 || per < best) best = per; \
+	} \
+	printf("%-28s %8.1f\n", name, best); \
+} while (0)
+
+static void setup_globals(void)
+{
+	mock_reset();
+	Plugins = &bench_plugins;
+	RegCmds = &bench_cmds;
+	RegCvars = &bench_cvars;
+	RegMsgs = &bench_msgs;
+	memset(&bench_config, 0, sizeof(bench_config));
+	bench_config.init(bench_options);
+	Config = &bench_config;
+	metamod_not_loaded = 0;
+
+	memset(&gamedll_table, 0, sizeof(gamedll_table));
+	gamedll_table.pfnThink = dll_void_p;
+	gamedll_table.pfnUse = dll_void_2p;
+	gamedll_table.pfnServerActivate = dll_void_p2i;
+	gamedll_table.pfnSaveWriteFields = dll_void_4pi;
+	GameDLL_funcs.dllapi_table = &gamedll_table;
+
+	memset(&engine_table, 0, sizeof(engine_table));
+	engine_table.pfnRunPlayerMove = eng_runplayermove;
+	engine_table.pfnPlaybackEvent = eng_playbackevent;
+	engine_table.pfnSetModel = eng_setmodel;
+	Engine_funcs = engine_table_ptr;
+
+	// One plugin hooking the same functions, so each dispatch walks a
+	// non-empty hook list the way a real server does.
+	memset(&plugin_pre_table, 0, sizeof(plugin_pre_table));
+	plugin_pre_table.pfnThink = plug_void_p;
+	plugin_pre_table.pfnUse = plug_void_2p;
+	plugin_pre_table.pfnServerActivate = plug_void_p2i;
+	plugin_pre_table.pfnSaveWriteFields = plug_void_4pi;
+
+	free(bench_plugins.hook_list_data);
+	memset(&bench_plugins, 0, sizeof(bench_plugins));
+	MPlugin *plug = &bench_plugins.plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->index = 1;
+	snprintf(plug->filename, sizeof(plug->filename), "bench_plugin");
+	plug->file = plug->filename;
+	plug->tables.dllapi = &plugin_pre_table;
+	bench_plugins.endlist = 1;
+	bench_plugins.rebuild_hook_lists();
+}
+
+int main(void)
+{
+	DLL_FUNCTIONS dll;
+	int version = INTERFACE_VERSION;
+	edict_t ed;
+	float vec[3] = { 1.0f, 2.0f, 3.0f };
+	SAVERESTOREDATA srd;
+	TYPEDESCRIPTION td;
+
+	memset(&ed, 0, sizeof(ed));
+	memset(&srd, 0, sizeof(srd));
+	memset(&td, 0, sizeof(td));
+
+	setup_globals();
+	meta_new_dll_functions_t::test_set_version(3);
+	memset(&dll, 0, sizeof(dll));
+	if (!GetEntityAPI2(&dll, &version)) {
+		printf("GetEntityAPI2 failed\n");
+		return 1;
+	}
+
+	printf("%-28s %8s   (%d iters, best of %d)\n", "wrapper (pack, args)", "ticks", ITERS, REPS);
+	printf("---------------------------------------------\n");
+
+	void (* volatile think)(edict_t *) = dll.pfnThink;
+	void (* volatile use)(edict_t *, edict_t *) = dll.pfnUse;
+	void (* volatile activate)(edict_t *, int, int) = dll.pfnServerActivate;
+	void (* volatile savefields)(SAVERESTOREDATA *, const char *, void *, TYPEDESCRIPTION *, int)
+		= dll.pfnSaveWriteFields;
+	void (* volatile setmodel)(edict_t *, const char *) = meta_engfuncs.pfnSetModel;
+	void (* volatile runmove)(edict_t *, const float *, float, float, float, unsigned short, byte, byte)
+		= meta_engfuncs.pfnRunPlayerMove;
+	void (* volatile playback)(int, const edict_t *, unsigned short, float, float *, float *,
+				   float, float, int, int, int, int) = meta_engfuncs.pfnPlaybackEvent;
+
+	BENCH("dllapi Think (p, 1)",        , (void)0, think(&ed));
+	BENCH("dllapi Use (2p, 2)",         , (void)0, use(&ed, &ed));
+	BENCH("dllapi ServerActivate (p2i, 3)", , (void)0, activate(&ed, 32, 16));
+	BENCH("dllapi SaveWriteFields (4pi, 5)", , (void)0, savefields(&srd, "n", &srd, &td, 1));
+	BENCH("engine SetModel (2p, 2)",    , (void)0, setmodel(&ed, "m"));
+	BENCH("engine RunPlayerMove (2p3fus2uc, 8)", , (void)0,
+	      runmove(&ed, vec, 1.0f, 2.0f, 3.0f, (unsigned short)0x1234, (byte)7, (byte)13));
+	BENCH("engine PlaybackEvent (ipusf2p2f4i, 12)", , (void)0,
+	      playback(1, &ed, (unsigned short)0x5678, 0.5f, vec, vec, 1.5f, 2.5f, 3, 4, 5, 6));
+
+	return 0;
+}

--- a/metamod/tests/stubs.cpp
+++ b/metamod/tests/stubs.cpp
@@ -19,14 +19,20 @@ extern __attribute__((weak)) const engine_info_t engine_info = {};
 __attribute__((weak)) gamedll_funcs_t GameDLL_funcs = {};
 __attribute__((weak)) mutil_funcs_t MetaUtilFunctions = {};
 __attribute__((weak)) enginefuncs_t *Engine_funcs = NULL;
-__attribute__((weak)) meta_enginefuncs_t meta_engfuncs;
+// Storage only, under the real symbol name, for tests that do not link
+// engine_api.o. A weak object of the real type would run its default
+// constructor even where engine_api.o's strong definition wins, and which
+// of the two runs last is unspecified: with LTO it was the default one,
+// which zeroed the table engine_api.o had just filled.
+__attribute__((weak, aligned(16)))
+char meta_engfuncs_stub_storage[sizeof(meta_enginefuncs_t)] __asm__("meta_engfuncs");
 
-__attribute__((weak)) void main_hook_function_void(unsigned int, enum_api_t, unsigned int, const void *) {}
-__attribute__((weak)) void *main_hook_function(const class_ret_t, unsigned int, enum_api_t, unsigned int, const void *) { return NULL; }
+__attribute__((weak)) void DLLINTERNAL main_hook_function_void(unsigned int, enum_api_t, unsigned int, const void *) {}
+__attribute__((weak)) void * DLLINTERNAL main_hook_function(const class_ret_t, unsigned int, enum_api_t, unsigned int, const void *) { return NULL; }
 
-__attribute__((weak)) void client_meta(edict_t *) {}
+__attribute__((weak)) void DLLINTERNAL client_meta(edict_t *) {}
 
-__attribute__((weak)) const char *META_UTIL_VarArgs(const char *, ...)
+__attribute__((weak)) const char * DLLINTERNAL META_UTIL_VarArgs(const char *, ...)
 {
 	static char buf[] = "";
 	return buf;

--- a/metamod/tests/test_api_args.cpp
+++ b/metamod/tests/test_api_args.cpp
@@ -1,0 +1,464 @@
+//
+// metamod-p - argument marshalling for every API hook wrapper
+//
+// A wrapper hands main_hook_function* the block the plugins and the gamedll
+// are called with, mostly by passing on the one it was entered with, which
+// only holds while that block really is the packed struct image.
+//
+// Every slot of every API table is driven with sentinel arguments and the
+// delivered block compared against them, so a wrapper that stops passing
+// its parameters through fails here instead of corrupting arguments.
+// Walking the tables covers a newly added wrapper as soon as it appears.
+//
+
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+
+#include <extdll.h>
+
+#include "metamod.h"
+#include "dllapi.h"
+#include "engine_api.h"
+#include "api_info.h"
+#include "api_hook.h"
+#include "meta_api.h"
+#include "meta_eiface.h"
+
+#include "mlist.h"
+#include "mreg.h"
+#include "conf_meta.h"
+
+#include "engine_mock.h"
+#include "test_common.h"
+
+meta_globals_t *gpMetaGlobals = &PublicMetaGlobals;
+
+// Reference wrappers: the same sources built with the argument copy forced
+// on, their entry points renamed by the makefile. Global variables are not
+// name-mangled, so the engine table is reachable as a plain slot array.
+extern "C" int ref_GetEntityAPI2(DLL_FUNCTIONS *pFunctionTable, int *interfaceVersion);
+extern "C" int ref_GetNewDLLFunctions(NEW_DLL_FUNCTIONS *pTable, int *interfaceVersion);
+extern void *ref_meta_engfuncs[];
+
+// A handful of wrappers consult metamod state before dispatching, so the
+// globals they reach have to exist.
+static MPluginList test_plugins("plugins.ini");
+static MRegCmdList test_reg_cmds;
+static MRegCvarList test_reg_cvars;
+static MRegMsgList test_reg_msgs;
+static MConfig test_config;
+static option_t test_options[] = {
+	{ NULL, CF_NONE, NULL, NULL }
+};
+
+static void setup_globals(void)
+{
+	mock_reset();
+	Plugins = &test_plugins;
+	RegCmds = &test_reg_cmds;
+	RegCvars = &test_reg_cvars;
+	RegMsgs = &test_reg_msgs;
+	memset(&test_config, 0, sizeof(test_config));
+	test_config.init(test_options);
+	Config = &test_config;
+	metamod_not_loaded = 0;
+}
+
+// api_info's tables name every api_caller. The dispatchers are replaced
+// below and never reach one, so the list is expanded here into stubs
+// rather than linking the real api_hook.o, whose dispatchers would clash.
+#define BEGIN_API_CALLER_FUNC(ret_type, args_type_code) \
+	void * DLLINTERNAL _COMBINE4(api_caller_, ret_type, _args_, args_type_code)(const void *, const void *) {
+#define END_API_CALLER_FUNC(ret_t, args_t, args)	return NULL; }
+#define END_API_CALLER_FUNC_void(args_t, args)		return NULL; }
+#define END_API_CALLER_FUNC_noargs(ret_t)		return NULL; }
+#define END_API_CALLER_FUNC_noargs_void()		return NULL; }
+
+#include "../api_caller_list.h"
+
+#undef BEGIN_API_CALLER_FUNC
+#undef END_API_CALLER_FUNC
+#undef END_API_CALLER_FUNC_void
+#undef END_API_CALLER_FUNC_noargs
+#undef END_API_CALLER_FUNC_noargs_void
+
+// An api_info entry names the caller that will consume the block, and the
+// caller determines the packed struct, so expanding the same list a second
+// time gives the exact block size to expect for every wrapper without
+// keeping a parallel list by hand.
+typedef struct {
+	const void *caller;
+	unsigned int nbytes;
+} caller_size_t;
+
+#define MAX_CALLER_SIZES 128
+static caller_size_t caller_sizes[MAX_CALLER_SIZES];
+static int num_caller_sizes;
+
+static void add_caller_size(const void *caller, unsigned int nbytes)
+{
+	if (num_caller_sizes >= MAX_CALLER_SIZES)
+		return;
+	caller_sizes[num_caller_sizes].caller = caller;
+	caller_sizes[num_caller_sizes].nbytes = nbytes;
+	num_caller_sizes++;
+}
+
+// Expanded inside a function body: entries in the list are punctuated with
+// stray semicolons, which are empty statements here but would not be
+// allowed between initialisers.
+#define BEGIN_API_CALLER_FUNC(ret_type, args_type_code) \
+	add_caller_size((const void *)_COMBINE4(api_caller_, ret_type, _args_, args_type_code), \
+			(unsigned int)sizeof(_COMBINE2(pack_args_type_, args_type_code)));
+#define END_API_CALLER_FUNC(ret_t, args_t, args)
+#define END_API_CALLER_FUNC_void(args_t, args)
+#define END_API_CALLER_FUNC_noargs(ret_t)
+#define END_API_CALLER_FUNC_noargs_void()
+
+static void init_caller_sizes(void)
+{
+	num_caller_sizes = 0;
+#include "../api_caller_list.h"
+}
+#define NUM_CALLER_SIZES num_caller_sizes
+
+// pack_args_type_void is an empty placeholder, not an argument image.
+#define NO_ARG_BYTES ((unsigned int)sizeof(pack_args_type_void))
+
+static unsigned int caller_block_size(const void *caller, int *known)
+{
+	int i;
+	for (i = 0; i < NUM_CALLER_SIZES; i++) {
+		if (caller_sizes[i].caller == caller) {
+			*known = 1;
+			return caller_sizes[i].nbytes;
+		}
+	}
+	*known = 0;
+	return 0;
+}
+
+// Widest packed struct, and therefore the most argument slots any wrapper
+// can hand over.
+#define MAX_ARG_BYTES 48
+#define MAX_ARG_SLOTS (MAX_ARG_BYTES / 4)
+
+static unsigned char seen_block[MAX_ARG_BYTES];
+static unsigned int seen_len;
+static int seen_calls;
+
+// Replaces the real dispatchers: records the block a wrapper delivered
+// without calling any plugin or gamedll function.
+void DLLINTERNAL main_hook_function_void(unsigned int, enum_api_t, unsigned int, const void *packed_args)
+{
+	seen_calls++;
+	memcpy(seen_block, packed_args, seen_len);
+}
+
+void * DLLINTERNAL main_hook_function(const class_ret_t, unsigned int, enum_api_t, unsigned int, const void *packed_args)
+{
+	seen_calls++;
+	memcpy(seen_block, packed_args, seen_len);
+	return NULL;
+}
+
+// ============================================================
+// Wrappers that legitimately deliver something other than their own
+// incoming block.
+// ============================================================
+
+enum { T_DLL, T_NEW, T_ENG };
+
+typedef struct {
+	int table;
+	unsigned int slot;	// index of the function pointer within the table
+	unsigned int prefix;	// leading bytes that are still the wrapper's own arguments
+	int ref_prefix_only;	// whether the reference may also diverge past it
+	const char *why;
+} exception_t;
+
+static const exception_t exceptions[] = {
+	// printf-style: past the first argument the block holds a formatted
+	// buffer rather than anything the caller passed, and each copy of the
+	// wrapper formats into a buffer of its own
+	{ T_ENG, offsetof(enginefuncs_t, pfnClientCommand) / 4, 4, 1, "varargs" },
+	{ T_ENG, offsetof(enginefuncs_t, pfnAlertMessage) / 4, 4, 1, "varargs" },
+	{ T_ENG, offsetof(enginefuncs_t, pfnEngineFprintf) / 4, 4, 1, "varargs" },
+	// kept on the packing path: the struct widens their sub-word arguments,
+	// so the block diverges from the incoming slots at the first of them.
+	// Both copies pack, so they must still agree over the whole block --
+	// which is what catches one of these being moved off that path.
+	{ T_ENG, offsetof(enginefuncs_t, pfnCRC32_ProcessByte) / 4, 4, 0, "sub-word" },
+	{ T_ENG, offsetof(enginefuncs_t, pfnRunPlayerMove) / 4, 20, 0, "sub-word" },
+	{ T_ENG, offsetof(enginefuncs_t, pfnPlaybackEvent) / 4, 8, 0, "sub-word" },
+};
+#define NUM_EXCEPTIONS ((int)(sizeof(exceptions) / sizeof(exceptions[0])))
+
+static const exception_t *find_exception(int table, unsigned int slot)
+{
+	int i;
+	for (i = 0; i < NUM_EXCEPTIONS; i++)
+		if (exceptions[i].table == table && exceptions[i].slot == slot)
+			return &exceptions[i];
+	return NULL;
+}
+
+// ============================================================
+// Driving a wrapper
+// ============================================================
+
+// Sentinels double as the pointer arguments a wrapper may dereference
+// before dispatching, so they address readable zeroed storage.
+static unsigned char arena[MAX_ARG_SLOTS * 256];
+static unsigned int sentinel[MAX_ARG_SLOTS];
+
+typedef void (*call_slots_t)(unsigned int, unsigned int, unsigned int, unsigned int,
+			     unsigned int, unsigned int, unsigned int, unsigned int,
+			     unsigned int, unsigned int, unsigned int, unsigned int);
+
+static void init_sentinels(void)
+{
+	unsigned int i;
+	memset(arena, 0, sizeof(arena));
+	for (i = 0; i < MAX_ARG_SLOTS; i++)
+		sentinel[i] = (unsigned int)(unsigned long)(arena + i * 256 + 16);
+}
+
+static void call_wrapper(void *fn)
+{
+	((call_slots_t)fn)(sentinel[0], sentinel[1], sentinel[2], sentinel[3],
+			   sentinel[4], sentinel[5], sentinel[6], sentinel[7],
+			   sentinel[8], sentinel[9], sentinel[10], sentinel[11]);
+	// A wrapper returning float leaves its result on the x87 stack, which
+	// nothing here pops; reset so repeated calls cannot overflow it.
+	__asm__ __volatile__ ("fninit");
+}
+
+// Returns 0 on success, 1 on a reported failure.
+static int check_table(const char *tabname, int table, void **slots, void **refslots,
+		       const api_info_t *info, unsigned int nslots,
+		       int *checked, int *skipped, int *noargs)
+{
+	unsigned int i;
+
+	for (i = 0; i < nslots; i++) {
+		const exception_t *exc;
+		const char *name;
+		unsigned int cmp_len;
+		int known = 0;
+
+		if (!slots[i])
+			continue;
+
+		name = info[i].name ? info[i].name : "?";
+
+		// Read exactly what this wrapper delivers, never past it.
+		seen_len = caller_block_size((const void *)info[i].api_caller, &known);
+		if (!known) {
+			printf("FAILED\n    %s[%u] (%s): api_caller is not in the caller list\n",
+			       tabname, i, name);
+			return 1;
+		}
+		if (seen_len > MAX_ARG_BYTES) {
+			printf("FAILED\n    %s[%u] (%s): block of %u bytes exceeds the %d byte maximum\n",
+			       tabname, i, name, seen_len, MAX_ARG_BYTES);
+			return 1;
+		}
+
+		// A wrapper taking no arguments has no block; only its dispatch is
+		// meaningful, and its pointer addresses the shared placeholder.
+		if (seen_len == NO_ARG_BYTES)
+			seen_len = 0;
+
+		exc = find_exception(table, i);
+		cmp_len = exc ? exc->prefix : seen_len;
+
+		memset(seen_block, 0, sizeof(seen_block));
+		seen_calls = 0;
+		setup_globals();
+
+		call_wrapper(slots[i]);
+
+		if (seen_calls != 1) {
+			printf("FAILED\n    %s[%u] (%s): dispatched %d times, expected 1\n",
+			       tabname, i, name, seen_calls);
+			return 1;
+		}
+
+		if (cmp_len && memcmp(seen_block, sentinel, cmp_len) != 0) {
+			printf("FAILED\n    %s[%u] (%s): delivered block != incoming arguments\n",
+			       tabname, i, name);
+			return 1;
+		}
+
+		// The reference wrapper builds its block from the argument list
+		// spelled out at the call site, which the shipped one no longer
+		// reads. Comparing the two is what detects a wrapper whose packed
+		// arguments were never simply its own parameters.
+		if (refslots && refslots[i]) {
+			unsigned char delivered[MAX_ARG_BYTES];
+			unsigned int ref_len = seen_len;
+
+			memcpy(delivered, seen_block, sizeof(delivered));
+
+			memset(seen_block, 0, sizeof(seen_block));
+			seen_calls = 0;
+			seen_len = ref_len;
+			setup_globals();
+
+			call_wrapper(refslots[i]);
+
+			if (seen_calls != 1) {
+				printf("FAILED\n    %s[%u] (%s): reference dispatched %d times\n",
+				       tabname, i, name, seen_calls);
+				return 1;
+			}
+			// The printf-style wrappers each format into their own stack
+			// buffer, so past the pass-through prefix the two copies point
+			// at different strings and are not expected to agree.
+			if (exc && exc->ref_prefix_only)
+				ref_len = exc->prefix;
+			if (ref_len && memcmp(seen_block, delivered, ref_len) != 0) {
+				printf("FAILED\n    %s[%u] (%s): block differs from the declared argument list\n",
+				       tabname, i, name);
+				return 1;
+			}
+		}
+
+		if (exc)
+			(*skipped)++;
+		else if (cmp_len)
+			(*checked)++;
+		else
+			(*noargs)++;
+	}
+	return 0;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+static int test_all_wrappers_pass_incoming_args(void)
+{
+	DLL_FUNCTIONS dll_funcs, ref_dll_funcs;
+	NEW_DLL_FUNCTIONS new_funcs, ref_new_funcs;
+	int version;
+	int checked = 0, skipped = 0, noargs = 0;
+
+	TEST("api wrappers - every table slot delivers its incoming arguments");
+
+	init_sentinels();
+	init_caller_sizes();
+	setup_globals();
+	// NEW_DLL_FUNCTIONS is version-gated; pick the version that exposes
+	// every slot so none is skipped here.
+	meta_new_dll_functions_t::test_set_version(3);
+
+	memset(&dll_funcs, 0, sizeof(dll_funcs));
+	version = INTERFACE_VERSION;
+	if (!GetEntityAPI2(&dll_funcs, &version)) {
+		printf("FAILED\n    GetEntityAPI2 refused version %d\n", version);
+		return 1;
+	}
+
+	memset(&new_funcs, 0, sizeof(new_funcs));
+	version = NEW_DLL_FUNCTIONS_VERSION;
+	if (!GetNewDLLFunctions(&new_funcs, &version)) {
+		printf("FAILED\n    GetNewDLLFunctions refused version %d\n", version);
+		return 1;
+	}
+
+	memset(&ref_dll_funcs, 0, sizeof(ref_dll_funcs));
+	version = INTERFACE_VERSION;
+	ref_GetEntityAPI2(&ref_dll_funcs, &version);
+	memset(&ref_new_funcs, 0, sizeof(ref_new_funcs));
+	version = NEW_DLL_FUNCTIONS_VERSION;
+	ref_GetNewDLLFunctions(&ref_new_funcs, &version);
+
+	if (check_table("DLL_FUNCTIONS", T_DLL, (void **)&dll_funcs, (void **)&ref_dll_funcs,
+			(const api_info_t *)&dllapi_info,
+			sizeof(dll_funcs) / sizeof(void *), &checked, &skipped, &noargs))
+		return 1;
+
+	if (check_table("NEW_DLL_FUNCTIONS", T_NEW, (void **)&new_funcs, (void **)&ref_new_funcs,
+			(const api_info_t *)&newapi_info,
+			sizeof(new_funcs) / sizeof(void *), &checked, &skipped, &noargs))
+		return 1;
+
+	if (check_table("enginefuncs_t", T_ENG, (void **)&meta_engfuncs, ref_meta_engfuncs,
+			(const api_info_t *)&engine_info,
+			sizeof(enginefuncs_t) / sizeof(void *), &checked, &skipped, &noargs))
+		return 1;
+
+	// Guard against a table that silently stopped being populated.
+	if (checked < 170) {
+		printf("FAILED\n    only %d wrappers exercised, expected at least 170\n", checked);
+		return 1;
+	}
+
+	PASS();
+	printf("    %d wrappers compared in full, %d prefix only, %d take no arguments\n",
+	       checked, skipped, noargs);
+	return 0;
+}
+
+// Every exception must name a slot that really is populated, so the list
+// cannot rot into silently excusing nothing.
+static int test_exception_list_is_live(void)
+{
+	DLL_FUNCTIONS dll_funcs;
+	int version, i;
+
+	TEST("api wrappers - exception list refers to live table slots");
+
+	setup_globals();
+	memset(&dll_funcs, 0, sizeof(dll_funcs));
+	version = INTERFACE_VERSION;
+	GetEntityAPI2(&dll_funcs, &version);
+
+	for (i = 0; i < NUM_EXCEPTIONS; i++) {
+		void **slots;
+		unsigned int nslots;
+
+		switch (exceptions[i].table) {
+		case T_ENG:
+			slots = (void **)&meta_engfuncs;
+			nslots = sizeof(enginefuncs_t) / sizeof(void *);
+			break;
+		case T_DLL:
+			slots = (void **)&dll_funcs;
+			nslots = sizeof(DLL_FUNCTIONS) / sizeof(void *);
+			break;
+		default:
+			continue;
+		}
+
+		ASSERT_TRUE(exceptions[i].slot < nslots);
+		if (!slots[exceptions[i].slot]) {
+			printf("FAILED\n    exception %d (%s) names an empty slot %u\n",
+			       i, exceptions[i].why, exceptions[i].slot);
+			return 1;
+		}
+		ASSERT_TRUE(exceptions[i].prefix > 0 && exceptions[i].prefix <= MAX_ARG_BYTES);
+	}
+
+	PASS();
+	return 0;
+}
+
+int main(void)
+{
+	int fail = 0;
+
+	mock_reset();
+
+	printf("test_api_args:\n");
+
+	fail |= test_all_wrappers_pass_incoming_args();
+	fail |= test_exception_list_is_live();
+
+	printf("\n%d/%d tests passed\n", tests_passed, tests_run);
+	return fail ? EXIT_FAILURE : EXIT_SUCCESS;
+}

--- a/metamod/tests/test_api_hook.cpp
+++ b/metamod/tests/test_api_hook.cpp
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stddef.h>
+#include <stdarg.h>
 #include <signal.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -1582,6 +1583,168 @@ static int test_reentry_does_not_clobber_outer_flag(void)
 }
 
 // ============================================================
+// api_caller argument marshalling
+//
+// A caller marshals in bulk from the packed struct, which only holds while
+// each pack_args_type_* stays laid out as the image of the slots its call
+// signature describes. Drift corrupts arguments rather than failing to
+// compile, so the caller list is expanded again here into reference callers
+// passing arguments one by one: the reference encodes the signature, the
+// real caller the struct layout, and the delivered blocks are compared.
+// ============================================================
+
+#define BEGIN_API_CALLER_FUNC(ret_type, args_type_code) \
+	void * _COMBINE4(ref_api_caller_, ret_type, _args_, args_type_code)(const void * func, const void * packed_args) { \
+		typedef _COMBINE2(pack_args_type_, args_type_code) pack_t; \
+		pack_t * p ATTRIBUTE(unused)= (pack_t *)packed_args;
+#define END_API_CALLER_FUNC(ret_t, args_t, args) \
+		return(*(void **)class_ret_t((*(( ret_t (*) args_t )func)) args).getptr()); \
+	}
+#define END_API_CALLER_FUNC_void(args_t, args) \
+		return((*(( void* (*) args_t )func)) args); \
+	}
+#define END_API_CALLER_FUNC_noargs(ret_t) \
+		return(*(void **)class_ret_t((*(( ret_t (*)(void) )func))()).getptr()); \
+	}
+#define END_API_CALLER_FUNC_noargs_void() \
+		return((*(( void* (*)(void) )func))()); \
+	}
+
+#include "../api_caller_list.h"
+
+static unsigned char abi_seen[64];
+static unsigned char abi_ref[64];
+static unsigned int abi_seen_len;
+
+// Receivers copy the block they were called with. The address of the first
+// parameter will not do: clang, and any compiler under a sanitizer, keeps
+// that parameter somewhere of its own and leaves the rest of the block
+// behind. va_start points into the block itself, the variadic arguments
+// living nowhere else, one slot past the first parameter.
+//
+// Externally visible so GCC cannot give them a local calling convention,
+// and NOINLINE so an inlined one does not leave no block at all.
+static NOINLINE void abi_record(va_list past_first)
+{
+	const char *first = (const char *)past_first - sizeof(int);
+	memcpy(abi_seen, first, abi_seen_len);
+}
+
+NOINLINE void *abi_capture(int a0, ...);
+NOINLINE void *abi_capture(int a0, ...)
+{
+	va_list ap;
+	va_start(ap, a0);
+	abi_record(ap);
+	va_end(ap);
+	return NULL;
+}
+
+// Callers whose signature returns float must reach a float-returning
+// target, otherwise the caller's fstp runs on an empty x87 stack.
+NOINLINE float abi_capture_float(int a0, ...);
+NOINLINE float abi_capture_float(int a0, ...)
+{
+	va_list ap;
+	va_start(ap, a0);
+	abi_record(ap);
+	va_end(ap);
+	return 0.0f;
+}
+
+#define AP(n) ((const void *)(0x10000000 + (n) * 0x11111))
+
+// A caller reaches its target through an opaque pointer, and the target's
+// real signature never matches the one the caller casts to. Hand the
+// receivers over through volatile pointers so an optimizing build cannot
+// recover their identity, devirtualize the indirect call and re-type the
+// arguments to the receiver's own declaration.
+static void * volatile abi_recv;
+static void * volatile abi_recv_float;
+
+#define ABI_CHECK_TO(recv, ret_type, type, ctor_args) do { \
+	pack_args_type_##type pk ctor_args; \
+	abi_seen_len = (unsigned int)sizeof(pk); \
+	memset(abi_ref, 0, sizeof(abi_ref)); \
+	memset(abi_seen, 0, sizeof(abi_seen)); \
+	_COMBINE4(ref_api_caller_, ret_type, _args_, type)((const void *)recv, &pk); \
+	memcpy(abi_ref, abi_seen, sizeof(abi_ref)); \
+	memset(abi_seen, 0, sizeof(abi_seen)); \
+	_COMBINE4(api_caller_, ret_type, _args_, type)((const void *)recv, &pk); \
+	if (memcmp(abi_seen, abi_ref, abi_seen_len) != 0) { \
+		printf("FAILED\n    %s: bulk arg block != declared signature\n", #type); \
+		return 1; \
+	} \
+	if (memcmp(abi_seen, &pk, sizeof(pk)) != 0) { \
+		printf("FAILED\n    %s: arg block != packed struct image\n", #type); \
+		return 1; \
+	} \
+} while (0)
+
+#define ABI_CHECK(ret_type, type, ctor_args) \
+	ABI_CHECK_TO(abi_recv, ret_type, type, ctor_args)
+
+static int test_api_caller_arg_block_abi(void)
+{
+	TEST("api_caller - bulk arg block matches declared signature");
+
+	abi_recv = (void *)abi_capture;
+	abi_recv_float = (void *)abi_capture_float;
+
+	ABI_CHECK_TO(abi_recv_float, float, 2f, (1.5f, 2.25f));
+
+	ABI_CHECK(int, 2i, (11, 12));
+	ABI_CHECK(void, 2i2p, (21, 22, AP(1), AP(2)));
+	ABI_CHECK(void, 2i2pi2p, (31, 32, AP(1), AP(2), 33, AP(3), AP(4)));
+	ABI_CHECK(int, 2p, (AP(1), AP(2)));
+	ABI_CHECK(void, 2p2f, (AP(1), AP(2), 1.5f, 2.25f));
+	ABI_CHECK(void, 2p2i2p, (AP(1), AP(2), 41, 42, AP(3), AP(4)));
+	ABI_CHECK(void, 2p3fus2uc, (AP(1), AP(2), 1.5f, 2.25f, 3.125f, 0xbeef, 0x5a, 0xa5));
+	ABI_CHECK(void, 2pV, (AP(1), AP(2), AP(3)));
+	ABI_CHECK(ptr, 2pf, (AP(1), AP(2), 1.5f));
+	ABI_CHECK(void, 2pfi, (AP(1), AP(2), 1.5f, 51));
+	ABI_CHECK(int, 2pi, (AP(1), AP(2), 61));
+	ABI_CHECK(void, 2pi2p, (AP(1), AP(2), 71, AP(3), AP(4)));
+	ABI_CHECK(void, 2pif2p, (AP(1), AP(2), 81, 1.5f, AP(3), AP(4)));
+	ABI_CHECK(void, 2pui, (AP(1), AP(2), 0x91919191u));
+	ABI_CHECK(int, 3i, (101, 102, 103));
+	ABI_CHECK(int, 3p, (AP(1), AP(2), AP(3)));
+	ABI_CHECK(void, 3p2f2i, (AP(1), AP(2), AP(3), 1.5f, 2.25f, 111, 112));
+	ABI_CHECK(int, 3pi2p, (AP(1), AP(2), AP(3), 121, AP(4), AP(5)));
+	ABI_CHECK(int, 4p, (AP(1), AP(2), AP(3), AP(4)));
+	ABI_CHECK(int, 4pi, (AP(1), AP(2), AP(3), AP(4), 131));
+	ABI_CHECK(void, f, (1.5f));
+	ABI_CHECK(int, i, (141));
+	ABI_CHECK(int, i2p, (151, AP(1), AP(2)));
+	ABI_CHECK(void, i3p, (161, AP(1), AP(2), AP(3)));
+	ABI_CHECK(int, ip, (171, AP(1)));
+	ABI_CHECK(void, ipV, (181, AP(1), AP(2)));
+	ABI_CHECK(void, ipusf2p2f4i,
+		  (191, AP(1), 0xc0de, 1.5f, AP(2), AP(3), 2.25f, 3.125f, 192, 193, 194, 195));
+	ABI_CHECK(char, p, (AP(1)));
+	ABI_CHECK(void, p2f, (AP(1), 1.5f, 2.25f));
+	ABI_CHECK(int, p2fi, (AP(1), 1.5f, 2.25f, 201));
+	ABI_CHECK(void, p2i, (AP(1), 211, 212));
+	ABI_CHECK(void, p3i, (AP(1), 221, 222, 223));
+	ABI_CHECK(void, p4i, (AP(1), 231, 232, 233, 234));
+	ABI_CHECK(void, pf, (AP(1), 1.5f));
+	ABI_CHECK(void, pfp, (AP(1), 1.5f, AP(2)));
+	ABI_CHECK(int, pi, (AP(1), 241));
+	ABI_CHECK(void, pi2p, (AP(1), 251, AP(2), AP(3)));
+	ABI_CHECK(int, pi2p2ip, (AP(1), 261, AP(2), AP(3), 262, 263, AP(4)));
+	ABI_CHECK(ptr, pip, (AP(1), 271, AP(2)));
+	ABI_CHECK(void, pip2f2i, (AP(1), 281, AP(2), 1.5f, 2.25f, 282, 283));
+	ABI_CHECK(void, pip2f4i2p,
+		  (AP(1), 291, AP(2), 1.5f, 2.25f, 292, 293, 294, 295, AP(3), AP(4)));
+	ABI_CHECK(void, puc, (AP(1), 0x7e));
+	ABI_CHECK(ptr, ui, (0x31313131u));
+	ABI_CHECK(ulong, ul, (0x41414141ul));
+
+	PASS();
+	return 0;
+}
+
+// ============================================================
 // main
 // ============================================================
 
@@ -1666,6 +1829,9 @@ int main(void)
 	fail |= test_flag_cleared_after_outermost_returns();
 	fail |= test_reentry_rebuild_propagates_return_type();
 	fail |= test_reentry_does_not_clobber_outer_flag();
+
+	// api_caller argument marshalling
+	fail |= test_api_caller_arg_block_abi();
 
 	printf("\n%d/%d tests passed\n", tests_passed, tests_run);
 	return fail ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/metamod/tests/test_game_support.cpp
+++ b/metamod/tests/test_game_support.cpp
@@ -20,7 +20,7 @@
 #include "test_common.h"
 
 // install_gamedll is DLLINTERNAL, declare it for testing
-extern mBOOL install_gamedll(char *from, const char *to);
+extern mBOOL DLLINTERNAL install_gamedll(char *from, const char *to);
 
 // ============================================================
 // Temp directory helpers


### PR DESCRIPTION
The hook path copied arguments a field at a time, twice per call: once into a packed struct, then again onto the stack for each plugin. On i386 every argument occupies a 4-byte slot and each `pack_args_type_*` is already the exact image of those slots, so both copies can move the whole block at once.

- `api_caller` passes the packed struct by value, which is the identical stack block. Across all callers, 313 `push` become 129 `push` plus 64 SSE ops. `api_caller_void_args_pip2f4i2p` goes from 11 `push` to 3 `movdqu`/`movups` pairs with an unchanged frame.
- Hook wrappers hand over the block they were entered with instead of copying their parameters into a local struct. This one pays on every API call, not just per hooked plugin.

`metamod.so` .text 165342 -> 162642.

The three wrappers taking sub-word arguments keep packing: the struct holds those arguments widened where the incoming slot's high bits are undefined. Bulk-copying the block and widening those slots in place was tried and dropped -- it saves 6 instructions and measures 20-25% *slower*, since narrow stores into a block that is then read back wide defeat store forwarding.

`make -C metamod/tests bench` times dispatch directly, which is what caught that; on a live server metamod is ~3% of cycles and bot load varies more between runs than this change moves, so neither perf sampling nor META_PERFMON could resolve it. Against the base branch the remaining change measures neutral on dispatch cost (-0.3% to +1.3% across seven wrappers, min of six interleaved rounds); the win it does deliver is code size and instruction count, not measured time.

The passthrough is GCC-only: it relies on the address of the first parameter being the incoming block, which the ABI does not promise. GCC leaves stack parameters where they arrived; clang copies out the one whose address is taken, so it keeps the old path.

Two fixes found while building the test coverage for this:

- `autodetect_gamedll` passed 256-byte buffers to `full_gamedir_path`, which resolves through `realpath` and writes up to `PATH_MAX`.
- `~MPluginList` and `~MPlayer` were `DLLINTERNAL`, so regparm, but `__cxa_atexit` calls destructors as plain cdecl.

## Testing

`test_api_args` drives every slot of every API table with sentinel arguments and compares the delivered block. It walks the tables rather than a fixed list, so a new wrapper is covered as soon as it appears, and the wrappers are built a second time with the copy forced on so the two can be compared -- the declared argument list is otherwise inert once a wrapper hands its block over directly. `test_api_hook` does the same for the callers. Drift was injected in both directions to confirm the comparisons fail.

Two new CI jobs, after finding that argument marshalling can be correct at `-O0` and wrong at `-O2`, and correct without PIC/regparm and wrong with them:

- `make run-opt` builds the suite at `-O2`
- `make run-release` builds it the way `metamod.so` is built, including `-flto=auto`

854/854 with gcc at `-O0`, `-O2` and release flags, and with clang at `-O0` and `-O2`. Clean gcc and win32 builds. The win32 argument blocks were checked by running the mingw-built callers under wine. Local rehlds run with amxmodx, jk_botti and fakemeta loaded.


