### PR TITLE
Per-function hook lists for api_hook dispatch

### DIFF
--- a/metamod/api_hook.cpp
+++ b/metamod/api_hook.cpp
@@ -127,13 +127,15 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 	PublicMetaGlobals.prev_mres=MRES_UNSET;
 	rebuild_happened = hook_list_tables_updated;
 	hook_list_tables_updated = mFALSE;
-	list = Plugins->get_hook_list(api);
+	list = Plugins->get_hook_list(api, func_offset);
 	count = list->count;
 	plugs = list->plugs;
 	for(i=0; likely(i < count); i++) {
 		MPlugin *plug = plugs[i];
+		// Listed plugins hook this function, unless one dropped its own
+		// table entry since the list was built.
 		void *pfn_routine=get_api_function(plug->get_api_table(api), func_offset);
-		if(likely(!pfn_routine))
+		if(unlikely(!pfn_routine))
 			continue;
 
 		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plug->file, api_info.name));
@@ -149,7 +151,7 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 		if(unlikely(hook_list_tables_updated)) {
 			hook_list_tables_updated = mFALSE;
 			rebuild_happened = mTRUE;
-			i = Plugins->find_plugin_after_rebuild(api, mFALSE, plug, count, plugs);
+			i = Plugins->find_plugin_after_rebuild(api, func_offset, mFALSE, plug, count, plugs);
 		}
 
 		// plugin's result code
@@ -194,13 +196,13 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 	PublicMetaGlobals.prev_mres=MRES_UNSET;
 	rebuild_happened = (mBOOL)(rebuild_happened | hook_list_tables_updated);
 	hook_list_tables_updated = mFALSE;
-	list = Plugins->get_hook_post_list(api);
+	list = Plugins->get_hook_post_list(api, func_offset);
 	count = list->count;
 	plugs = list->plugs;
 	for(i=0; likely(i < count); i++) {
 		MPlugin *plug = plugs[i];
 		void *pfn_routine=get_api_function(plug->get_api_post_table(api), func_offset);
-		if(likely(!pfn_routine))
+		if(unlikely(!pfn_routine))
 			continue;
 
 		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plug->file, api_info.name));
@@ -216,7 +218,7 @@ static inline HOT_FUNC void DLLINTERNAL main_hook_function_void_t(unsigned int a
 		if(unlikely(hook_list_tables_updated)) {
 			hook_list_tables_updated = mFALSE;
 			rebuild_happened = mTRUE;
-			i = Plugins->find_plugin_after_rebuild(api, mTRUE, plug, count, plugs);
+			i = Plugins->find_plugin_after_rebuild(api, func_offset, mTRUE, plug, count, plugs);
 		}
 
 		// plugin's result code
@@ -289,13 +291,15 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 	//Pre plugin functions
 	PublicMetaGlobals.prev_mres = MRES_UNSET;
 	rebuild_happened = hook_list_tables_updated;
-	list = Plugins->get_hook_list(api);
+	list = Plugins->get_hook_list(api, func_offset);
 	count = list->count;
 	plugs = list->plugs;
 	for(i=0; likely(i < count); i++) {
 		MPlugin *plug = plugs[i];
+		// Listed plugins hook this function, unless one dropped its own
+		// table entry since the list was built.
 		void *pfn_routine=get_api_function(plug->get_api_table(api), func_offset);
-		if(likely(!pfn_routine))
+		if(unlikely(!pfn_routine))
 			continue;
 
 		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s()", plug->file, api_info.name));
@@ -317,7 +321,7 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 		if(unlikely(hook_list_tables_updated)) {
 			hook_list_tables_updated = mFALSE;
 			rebuild_happened = mTRUE;
-			i = Plugins->find_plugin_after_rebuild(api, mFALSE, plug, count, plugs);
+			i = Plugins->find_plugin_after_rebuild(api, func_offset, mFALSE, plug, count, plugs);
 		}
 
 		// plugin's result code
@@ -369,13 +373,13 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 	PublicMetaGlobals.prev_mres = MRES_UNSET;
 	rebuild_happened = (mBOOL)(rebuild_happened | hook_list_tables_updated);
 	hook_list_tables_updated = mFALSE;
-	list = Plugins->get_hook_post_list(api);
+	list = Plugins->get_hook_post_list(api, func_offset);
 	count = list->count;
 	plugs = list->plugs;
 	for(i=0; likely(i < count); i++) {
 		MPlugin *plug = plugs[i];
 		void *pfn_routine=get_api_function(plug->get_api_post_table(api), func_offset);
-		if(likely(!pfn_routine))
+		if(unlikely(!pfn_routine))
 			continue;
 
 		MAYBE_META_DEBUG(do_debug, api_info.loglevel, ("Calling %s:%s_Post()", plug->file, api_info.name));
@@ -397,7 +401,7 @@ static inline HOT_FUNC void * DLLINTERNAL main_hook_function_t(const class_ret_t
 		if(unlikely(hook_list_tables_updated)) {
 			hook_list_tables_updated = mFALSE;
 			rebuild_happened = mTRUE;
-			i = Plugins->find_plugin_after_rebuild(api, mTRUE, plug, count, plugs);
+			i = Plugins->find_plugin_after_rebuild(api, func_offset, mTRUE, plug, count, plugs);
 		}
 
 		// plugin's result code

--- a/metamod/dllapi.cpp
+++ b/metamod/dllapi.cpp
@@ -219,6 +219,12 @@ static HOT_FUNC FORCE_STACK_ALIGN void mm_PlayerPostThink(edict_t *pEntity) {
 static HOT_FUNC FORCE_STACK_ALIGN void mm_StartFrame(void) {
 	meta_debug_value = (int)meta_debug.value;
 
+	// Catch plugins that installed a hook into their own table since the
+	// lists were built.  Done here, before dispatching, so that no hook
+	// list is being walked at the moment a rebuild happens.
+	if(likely(Plugins != NULL))
+		Plugins->refresh_hook_lists_if_changed();
+
 	META_DLLAPI_HANDLE_void(FN_STARTFRAME, pfnStartFrame, void, (VOID_ARG));
 	RETURN_API_void();
 }

--- a/metamod/mlist.cpp
+++ b/metamod/mlist.cpp
@@ -50,6 +50,29 @@
 
 HOT_DATA mBOOL DLLHIDDEN hook_list_tables_updated = mFALSE;
 
+// Turning a func_offset into a slot index only works while these tables are
+// nothing but pointer-sized slots, and none of them may outgrow the stride.
+typedef char assert_engine_table_slots[sizeof(enginefuncs_t) % sizeof(void *) == 0 ? 1 : -1];
+typedef char assert_dllapi_table_slots[sizeof(DLL_FUNCTIONS) % sizeof(void *) == 0 ? 1 : -1];
+typedef char assert_newapi_table_slots[sizeof(NEW_DLL_FUNCTIONS) % sizeof(void *) == 0 ? 1 : -1];
+typedef char assert_engine_table_fits[HOOK_SLOTS_ENGINE <= HOOK_SLOTS_STRIDE ? 1 : -1];
+typedef char assert_dllapi_table_fits[HOOK_SLOTS_DLLAPI <= HOOK_SLOTS_STRIDE ? 1 : -1];
+typedef char assert_newapi_table_fits[HOOK_SLOTS_NEWAPI <= HOOK_SLOTS_STRIDE ? 1 : -1];
+
+// Slots per group, in enum_api_t order.
+HOT_RODATA const int DLLHIDDEN api_hook_slot_count[3] = {
+	HOOK_SLOTS_ENGINE,
+	HOOK_SLOTS_DLLAPI,
+	HOOK_SLOTS_NEWAPI,
+};
+
+// Where each group starts inside one plugin's hook_shadow row.
+static HOT_RODATA const int shadow_slot_base[3] = {
+	0,						// e_api_engine
+	HOOK_SLOTS_ENGINE,				// e_api_dllapi
+	HOOK_SLOTS_ENGINE + HOOK_SLOTS_DLLAPI,		// e_api_newapi
+};
+
 // Constructor
 MPluginList::MPluginList(const char *ifile)
 	: size(MAX_PLUGINS), endlist(0)
@@ -171,25 +194,36 @@ void DLLINTERNAL MPluginList::trim_list(void) {
 }
 
 void DLLINTERNAL MPluginList::rebuild_hook_lists(void) {
-	int i, total;
+	int i, api, slot, total;
+	const int nlists = 3 * HOOK_SLOTS_STRIDE * 2;
 
 	memset(hook_lists, 0, sizeof(hook_lists));
 
-	// First pass: count entries per list.
+	// First pass: count entries per list.  A plugin lands in the list of
+	// every function it hooks, so both passes walk its tables slot by slot.
 	for(i = 0; i < endlist; i++) {
 		if(plist[i].status != PL_RUNNING)
 			continue;
-		for(int api = 0; api < 3; api++) {
-			if(plist[i].get_api_table((enum_api_t)api))
-				hook_lists[api][0].count++;
-			if(plist[i].get_api_post_table((enum_api_t)api))
-				hook_lists[api][1].count++;
+		for(api = 0; api < 3; api++) {
+			const int nslots = api_hook_slot_count[api];
+			void **table = (void **)plist[i].get_api_table((enum_api_t)api);
+			if(table) {
+				for(slot = 0; slot < nslots; slot++)
+					if(table[slot])
+						hook_lists[api][slot][0].count++;
+			}
+			table = (void **)plist[i].get_api_post_table((enum_api_t)api);
+			if(table) {
+				for(slot = 0; slot < nslots; slot++)
+					if(table[slot])
+						hook_lists[api][slot][1].count++;
+			}
 		}
 	}
 
 	// Allocate single block for all lists back-to-back.
 	total = 0;
-	for(i = 0; i < 6; i++)
+	for(i = 0; i < nlists; i++)
 		total += ((api_plugin_list_t *)hook_lists)[i].count;
 
 	if(total > 0) {
@@ -206,28 +240,114 @@ void DLLINTERNAL MPluginList::rebuild_hook_lists(void) {
 		hook_list_data = NULL;
 	}
 
-	// Assign plugs pointers into the allocation.
+	// Assign plugs pointers into the allocation, and zero the counts again
+	// so the second pass can use them as write cursors.
 	MPlugin **ptr = hook_list_data;
-	for(i = 0; i < 6; i++) {
+	for(i = 0; i < nlists; i++) {
 		api_plugin_list_t *list = &((api_plugin_list_t *)hook_lists)[i];
 		list->plugs = list->count ? ptr : NULL;
 		ptr += list->count;
+		list->count = 0;
 	}
 
-	// Second pass: fill in plugin pointers (reuse counts as write indices).
-	int idx[3][2] = {};
+	// Second pass: fill in plugin pointers.  Ascending plist order, which
+	// find_plugin_after_rebuild() relies on to locate a plugin by address.
 	for(i = 0; i < endlist; i++) {
 		if(plist[i].status != PL_RUNNING)
 			continue;
-		for(int api = 0; api < 3; api++) {
-			if(plist[i].get_api_table((enum_api_t)api))
-				hook_lists[api][0].plugs[idx[api][0]++] = &plist[i];
-			if(plist[i].get_api_post_table((enum_api_t)api))
-				hook_lists[api][1].plugs[idx[api][1]++] = &plist[i];
+		for(api = 0; api < 3; api++) {
+			const int nslots = api_hook_slot_count[api];
+			void **table = (void **)plist[i].get_api_table((enum_api_t)api);
+			if(table) {
+				for(slot = 0; slot < nslots; slot++) {
+					if(table[slot]) {
+						api_plugin_list_t *list = &hook_lists[api][slot][0];
+						list->plugs[list->count++] = &plist[i];
+					}
+				}
+			}
+			table = (void **)plist[i].get_api_post_table((enum_api_t)api);
+			if(table) {
+				for(slot = 0; slot < nslots; slot++) {
+					if(table[slot]) {
+						api_plugin_list_t *list = &hook_lists[api][slot][1];
+						list->plugs[list->count++] = &plist[i];
+					}
+				}
+			}
 		}
 	}
 
+	snapshot_hook_tables();
+
 	hook_list_tables_updated = mTRUE;
+}
+
+// Record what every running plugin currently has in its tables, so that a
+// later edit can be spotted.  Slots of a table the plugin did not register
+// are zeroed, so the comparison never reads a table that is not there.
+void DLLINTERNAL MPluginList::snapshot_hook_tables(void) {
+	int i, api, post;
+
+	for(i = 0; i < endlist; i++) {
+		if(plist[i].status != PL_RUNNING) {
+			memset(hook_shadow[i], 0, sizeof(hook_shadow[i]));
+			continue;
+		}
+		for(api = 0; api < 3; api++) {
+			const size_t nbytes = api_hook_slot_count[api] * sizeof(void *);
+			for(post = 0; post < 2; post++) {
+				void *shadow = &hook_shadow[i][post][shadow_slot_base[api]];
+				void *table = post ? plist[i].get_api_post_table((enum_api_t)api)
+						   : plist[i].get_api_table((enum_api_t)api);
+				if(table)
+					memcpy(shadow, table, nbytes);
+				else
+					memset(shadow, 0, nbytes);
+			}
+		}
+	}
+}
+
+// Has any running plugin edited its own tables since the snapshot?  Called
+// once per frame, so it stops at the first difference: the answer is almost
+// always no, and that path is nothing but loads and compares.
+//
+// memcmp rather than anything cleverer on purpose.  A bit per slot would be
+// exact too, and touch half the memory, but building it means testing every
+// slot one at a time; measured at 15 plugins that costs 4387 ticks a frame
+// against 1038 for memcmp, which the C library already vectorises.
+mBOOL DLLINTERNAL MPluginList::hook_tables_changed(void) {
+	int i, api, post;
+
+	for(i = 0; i < endlist; i++) {
+		if(plist[i].status != PL_RUNNING)
+			continue;
+		for(api = 0; api < 3; api++) {
+			const size_t nbytes = api_hook_slot_count[api] * sizeof(void *);
+			for(post = 0; post < 2; post++) {
+				const void *shadow = &hook_shadow[i][post][shadow_slot_base[api]];
+				const void *table = post ? plist[i].get_api_post_table((enum_api_t)api)
+							 : plist[i].get_api_table((enum_api_t)api);
+				if(!table)
+					continue;
+				if(unlikely(memcmp(table, shadow, nbytes) != 0))
+					return(mTRUE);
+			}
+		}
+	}
+	return(mFALSE);
+}
+
+// Keep the per-function lists in step with plugins that install or drop
+// hooks while running.  Dropping one is already handled by the dispatcher,
+// which skips a NULL table entry; installing one needs the lists rebuilt,
+// and this is what notices.
+void DLLINTERNAL MPluginList::refresh_hook_lists_if_changed(void) {
+	if(unlikely(hook_tables_changed())) {
+		META_DEBUG(4, ("Plugin hook tables changed at runtime, rebuilding hook lists"));
+		rebuild_hook_lists();
+	}
 }
 
 // Find a plugin with the given plid.

--- a/metamod/mlist.h
+++ b/metamod/mlist.h
@@ -49,12 +49,44 @@
 // Width required to printf above MAX, for show() functions.
 #define WIDTH_MAX_PLUGINS	2
 
-// Pre-filtered plugin list for a single API group + phase combination.
-// Contains only running plugins that have a non-NULL table for that group.
+// Pre-filtered plugin list for a single API function + phase combination.
+// Contains only running plugins that hook that one function.
 struct api_plugin_list_t {
 	int count;
 	MPlugin **plugs;
 };
+
+// Hook lists are kept per API function rather than per API group.  A plugin
+// that registers a table fills a handful of its slots, and the tables hold
+// 159 (engine), 50 (dllapi) and 5 (newapi) of them, so one list per group
+// leaves every dispatch walking over the plugins that hook some other
+// function of the same table just to skip them.
+//
+// A function is addressed by its slot in its own table, which is what a
+// func_offset already is: every slot in these tables is pointer sized, and
+// the dispatcher relies on that when it reaches a table entry by byte
+// offset.  Each group gets the same power-of-two stride so that a dispatch
+// can reach its list by shifting func_offset rather than by loading a per
+// group base - one dependent load fewer on the hot path, which the shortest
+// wrappers do notice.  It costs the padding between HOOK_SLOTS_* and the
+// stride, all of it untouched.
+//
+// HOOK_SLOTS_* is how many slots a plugin's table has, which is what may be
+// scanned, and that is not sizeof() for the engine: mplugin.cpp allocates a
+// plugin's engine table without the extra_functions tail, so the reserved
+// slots are not there to read.
+#define HOOK_SLOTS_ENGINE	((int)((sizeof(enginefuncs_t) \
+					- sizeof(((enginefuncs_t *)0)->extra_functions)) / sizeof(void *)))
+#define HOOK_SLOTS_DLLAPI	((int)(sizeof(DLL_FUNCTIONS) / sizeof(void *)))
+#define HOOK_SLOTS_NEWAPI	((int)(sizeof(NEW_DLL_FUNCTIONS) / sizeof(void *)))
+#define HOOK_SLOTS_STRIDE	256
+
+// Slots per group, indexed by enum_api_t.
+extern const int DLLHIDDEN api_hook_slot_count[3];
+
+// Total slots a plugin can fill, across all three groups, for the shadow
+// copy below.
+#define HOOK_SLOTS_TOTAL	(HOOK_SLOTS_ENGINE + HOOK_SLOTS_DLLAPI + HOOK_SLOTS_NEWAPI)
 
 // Set by rebuild_hook_lists() to signal main_hook_function that cached
 // pointers are stale and need to be refreshed.
@@ -64,24 +96,39 @@ extern mBOOL DLLHIDDEN hook_list_tables_updated;
 class MPluginList : public class_metamod_new {
 	public:
 	// data:
-		api_plugin_list_t hook_lists[3][2];		// pre-filtered per-api [pre,post] plugin arrays
+		api_plugin_list_t hook_lists[3][HOOK_SLOTS_STRIDE][2];	// pre-filtered per-function [pre,post] plugin arrays
 		MPlugin **hook_list_data;			// backing allocation for hook_lists plugs pointers
+		// Copy of what every running plugin had in its tables when the
+		// hook lists were last built.  A plugin owns the table metamod
+		// handed it and some edit it while running - AMX Mod X's fakemeta
+		// register_forward() installs hooks that way - and the per-function
+		// lists have to follow.  Compared once per frame; see
+		// refresh_hook_lists_if_changed().
+		void *hook_shadow[MAX_PLUGINS][2][HOOK_SLOTS_TOTAL];
 		int size;					// size of list, ie MAX_PLUGINS
 		int endlist;					// index of last used entry
 		MPlugin plist[MAX_PLUGINS];			// array of plugins
 		char inifile[PATH_MAX];				// full pathname
 
-		inline DLLINTERNAL const api_plugin_list_t * get_hook_list(enum_api_t api) {
-			return(&hook_lists[api][0]);
+		// Both phases of one function: [0] is pre, [1] is post, on the
+		// same cache line.  A dispatch looks each phase up where it uses
+		// it: hoisting the pair to the top of main_hook_function costs
+		// more than the second index calculation, because the pointer
+		// then has to survive the plugin calls and gets spilled.
+		inline DLLINTERNAL const api_plugin_list_t * get_hook_lists(enum_api_t api, unsigned int func_offset) {
+			return(hook_lists[api][func_offset / sizeof(void *)]);
 		}
-		inline DLLINTERNAL const api_plugin_list_t * get_hook_post_list(enum_api_t api) {
-			return(&hook_lists[api][1]);
+		inline DLLINTERNAL const api_plugin_list_t * get_hook_list(enum_api_t api, unsigned int func_offset) {
+			return(&get_hook_lists(api, func_offset)[0]);
+		}
+		inline DLLINTERNAL const api_plugin_list_t * get_hook_post_list(enum_api_t api, unsigned int func_offset) {
+			return(&get_hook_lists(api, func_offset)[1]);
 		}
 		inline DLLINTERNAL int find_plugin_after_rebuild(
-			enum_api_t api, mBOOL post, MPlugin *current_plugin,
+			enum_api_t api, unsigned int func_offset, mBOOL post, MPlugin *current_plugin,
 			int &out_count, MPlugin * const * &out_plugs)
 		{
-			const api_plugin_list_t *list = &hook_lists[api][post ? 1 : 0];
+			const api_plugin_list_t *list = &get_hook_lists(api, func_offset)[post ? 1 : 0];
 			out_plugs = list->plugs;
 			out_count = list->count;
 			for(int j = 0; j < out_count; j++) {
@@ -122,6 +169,9 @@ class MPluginList : public class_metamod_new {
 		mBOOL DLLINTERNAL load(void);				// load the list, at startup
 		mBOOL DLLINTERNAL refresh(PLUG_LOADTIME now);		// update from re-read inifile
 		void DLLINTERNAL rebuild_hook_lists(void);
+		void DLLINTERNAL snapshot_hook_tables(void);
+		mBOOL DLLINTERNAL hook_tables_changed(void);
+		void DLLINTERNAL refresh_hook_lists_if_changed(void);
 		void DLLINTERNAL unpause_all(void);			// unpause any paused plugins
 		void DLLINTERNAL retry_all(PLUG_LOADTIME now);		// retry any pending plugin actions
 		void DLLINTERNAL show(int source_index);		// list plugins to console

--- a/metamod/tests/bench_api_hook.cpp
+++ b/metamod/tests/bench_api_hook.cpp
@@ -2,9 +2,22 @@
 // metamod-p - dispatch cost microbenchmark
 //
 // Drives real API wrappers in a fixed-iteration loop: wrapper ->
-// main_hook_function -> one hooked plugin -> gamedll/engine, with trivial
+// main_hook_function -> hooked plugins -> gamedll/engine, with trivial
 // callees so what is left is metamod's own dispatch and argument
 // marshalling. A live server buries that under ~97% unrelated cycles.
+//
+// Measured across several plugin populations, because a dispatch walks the
+// hook list for the api group and not for the function being called:
+//
+//   N  plugins registered a table for the api group, so they sit in that
+//      group's hook list and the dispatch loop walks over all of them
+//   K  of those N actually hook the function being called
+//
+// The N-K plugins in between hook other functions of the same table, which
+// is what a real plugin looks like: a table has 50 (dllapi), 175 (engine)
+// or 5 (newapi) slots and a plugin fills a handful. Every plugin gets its
+// own tables so the loads scatter the way they do when each table lives in
+// its own shared object.
 //
 // Reports TSC ticks per call, minimum of several repetitions so an
 // interrupt lands in the discarded runs rather than the reported one.
@@ -41,9 +54,16 @@ static MConfig bench_config;
 static option_t bench_options[] = { { NULL, CF_NONE, NULL, NULL } };
 
 static DLL_FUNCTIONS gamedll_table;
-static DLL_FUNCTIONS plugin_pre_table;
 static enginefuncs_t engine_table;
 static enginefuncs_t *engine_table_ptr = &engine_table;
+
+// One table per plugin, pre and post, so walking the list touches a
+// different cache line for every entry.
+#define MAX_BENCH_PLUGINS 40
+static DLL_FUNCTIONS bench_dll_tables[MAX_BENCH_PLUGINS];
+static DLL_FUNCTIONS bench_dll_post_tables[MAX_BENCH_PLUGINS];
+static enginefuncs_t bench_eng_tables[MAX_BENCH_PLUGINS];
+static enginefuncs_t bench_eng_post_tables[MAX_BENCH_PLUGINS];
 
 // ---------------------------------------------------------------
 // Callees. Empty, but not inlinable: what is being timed is the cost of
@@ -55,6 +75,19 @@ static NOINLINE void plug_void_2p(edict_t *, edict_t *) { PublicMetaGlobals.mres
 static NOINLINE void plug_void_p2i(edict_t *, int, int) { PublicMetaGlobals.mres = MRES_IGNORED; }
 static NOINLINE void plug_void_4pi(SAVERESTOREDATA *, const char *, void *, TYPEDESCRIPTION *, int)
 	{ PublicMetaGlobals.mres = MRES_IGNORED; }
+
+static NOINLINE void plug_setmodel(edict_t *, const char *) { PublicMetaGlobals.mres = MRES_IGNORED; }
+static NOINLINE void plug_runplayermove(edict_t *, const float *, float, float, float,
+					unsigned short, byte, byte)
+	{ PublicMetaGlobals.mres = MRES_IGNORED; }
+static NOINLINE void plug_playbackevent(int, const edict_t *, unsigned short, float, float *,
+					float *, float, float, int, int, int, int)
+	{ PublicMetaGlobals.mres = MRES_IGNORED; }
+
+// Hooks that are never called, so a plugin that does not hook the function
+// under test still holds a table with something in it.
+static NOINLINE void plug_filler_touch(edict_t *, edict_t *) { PublicMetaGlobals.mres = MRES_IGNORED; }
+static NOINLINE void plug_filler_setorigin(edict_t *, const float *) { PublicMetaGlobals.mres = MRES_IGNORED; }
 
 static NOINLINE void dll_void_p(edict_t *) {}
 static NOINLINE void dll_void_2p(edict_t *, edict_t *) {}
@@ -81,21 +114,58 @@ static inline unsigned long long rdtsc_now(void)
 #define ITERS 200000
 #define REPS  15
 
-// Each case is a block that calls the wrapper ITERS times; the wrapper is
-// reached through a volatile pointer so the call cannot be devirtualized
-// or hoisted.
-#define BENCH(name, decl_fn, setup, call) do { \
+// Calls the wrapper ITERS times and keeps the best per-call tick count. The
+// wrapper is reached through a volatile pointer so the call cannot be
+// devirtualized or hoisted.
+#define BENCH(slot, call) do { \
 	double best = 0; \
 	for (int rep = 0; rep < REPS; rep++) { \
-		setup; \
 		unsigned long long t0 = rdtsc_now(); \
 		for (int i = 0; i < ITERS; i++) { call; } \
 		unsigned long long t1 = rdtsc_now(); \
 		double per = (double)(t1 - t0) / ITERS; \
 		if (rep == 0 || per < best) best = per; \
 	} \
-	printf("%-28s %8.1f\n", name, best); \
+	(slot) = best; \
 } while (0)
+
+// ---------------------------------------------------------------
+// Plugin populations
+// ---------------------------------------------------------------
+
+struct bench_config_t {
+	const char *label;
+	int nplugins;		// plugins holding a table for the api group
+	int khooks;		// of those, how many hook the timed function
+	int with_post;		// also register post tables, hooking nothing
+};
+
+#define NCONFIGS  6
+#define NWRAPPERS 7
+
+// K=0 is the case a server spends most of its time in: of the 214 functions
+// across the three tables, any one of them is hooked by nobody far more
+// often than by somebody, and the wrappers are called regardless.
+static const bench_config_t configs[NCONFIGS] = {
+	{ "N=1/K=1",        1, 1, 0 },
+	{ "N=5/K=1",        5, 1, 0 },
+	{ "N=20/K=2",      20, 2, 0 },
+	{ "N=40/K=2",      40, 2, 0 },
+	{ "N=20/K=2+post", 20, 2, 1 },
+	{ "N=20/K=0",      20, 0, 0 },
+};
+
+static const char *wrapper_names[NWRAPPERS] = {
+	"dllapi Think (p, 1)",
+	"dllapi Use (2p, 2)",
+	"dllapi ServerActivate (p2i, 3)",
+	"dllapi SaveWriteFields (4pi, 5)",
+	"engine SetModel (2p, 2)",
+	"engine RunPlayerMove (2p3fus2uc, 8)",
+	"engine PlaybackEvent (ipusf2p2f4i, 12)",
+};
+
+static double results[NCONFIGS][NWRAPPERS];
 
 static void setup_globals(void)
 {
@@ -121,25 +191,64 @@ static void setup_globals(void)
 	engine_table.pfnPlaybackEvent = eng_playbackevent;
 	engine_table.pfnSetModel = eng_setmodel;
 	Engine_funcs = engine_table_ptr;
+}
 
-	// One plugin hooking the same functions, so each dispatch walks a
-	// non-empty hook list the way a real server does.
-	memset(&plugin_pre_table, 0, sizeof(plugin_pre_table));
-	plugin_pre_table.pfnThink = plug_void_p;
-	plugin_pre_table.pfnUse = plug_void_2p;
-	plugin_pre_table.pfnServerActivate = plug_void_p2i;
-	plugin_pre_table.pfnSaveWriteFields = plug_void_4pi;
+// Builds a population of n running plugins, k of them hooking the functions
+// under test, spread evenly through the list.
+static void setup_plugins(int n, int k, int with_post)
+{
+	char is_hooker[MAX_BENCH_PLUGINS];
+	int i, j;
+
+	memset(is_hooker, 0, sizeof(is_hooker));
+	for (j = 0; j < k; j++)
+		is_hooker[(j * n) / k] = 1;
 
 	free(bench_plugins.hook_list_data);
 	memset(&bench_plugins, 0, sizeof(bench_plugins));
-	MPlugin *plug = &bench_plugins.plist[0];
-	memset(plug, 0, sizeof(*plug));
-	plug->status = PL_RUNNING;
-	plug->index = 1;
-	snprintf(plug->filename, sizeof(plug->filename), "bench_plugin");
-	plug->file = plug->filename;
-	plug->tables.dllapi = &plugin_pre_table;
-	bench_plugins.endlist = 1;
+
+	for (i = 0; i < n; i++) {
+		DLL_FUNCTIONS *dt = &bench_dll_tables[i];
+		DLL_FUNCTIONS *dpt = &bench_dll_post_tables[i];
+		enginefuncs_t *et = &bench_eng_tables[i];
+		enginefuncs_t *ept = &bench_eng_post_tables[i];
+		MPlugin *plug = &bench_plugins.plist[i];
+
+		memset(dt, 0, sizeof(*dt));
+		memset(dpt, 0, sizeof(*dpt));
+		memset(et, 0, sizeof(*et));
+		memset(ept, 0, sizeof(*ept));
+
+		// Something this plugin hooks other than what is timed.
+		dt->pfnTouch = plug_filler_touch;
+		dpt->pfnTouch = plug_filler_touch;
+		et->pfnSetOrigin = plug_filler_setorigin;
+		ept->pfnSetOrigin = plug_filler_setorigin;
+
+		if (is_hooker[i]) {
+			dt->pfnThink = plug_void_p;
+			dt->pfnUse = plug_void_2p;
+			dt->pfnServerActivate = plug_void_p2i;
+			dt->pfnSaveWriteFields = plug_void_4pi;
+			et->pfnSetModel = plug_setmodel;
+			et->pfnRunPlayerMove = plug_runplayermove;
+			et->pfnPlaybackEvent = plug_playbackevent;
+		}
+
+		memset(plug, 0, sizeof(*plug));
+		plug->status = PL_RUNNING;
+		plug->index = i + 1;
+		snprintf(plug->filename, sizeof(plug->filename), "bench_plugin%d", i);
+		plug->file = plug->filename;
+		plug->tables.dllapi = dt;
+		plug->tables.engine = et;
+		if (with_post) {
+			plug->post_tables.dllapi = dpt;
+			plug->post_tables.engine = ept;
+		}
+	}
+
+	bench_plugins.endlist = n;
 	bench_plugins.rebuild_hook_lists();
 }
 
@@ -151,6 +260,7 @@ int main(void)
 	float vec[3] = { 1.0f, 2.0f, 3.0f };
 	SAVERESTOREDATA srd;
 	TYPEDESCRIPTION td;
+	int c, w;
 
 	memset(&ed, 0, sizeof(ed));
 	memset(&srd, 0, sizeof(srd));
@@ -164,9 +274,6 @@ int main(void)
 		return 1;
 	}
 
-	printf("%-28s %8s   (%d iters, best of %d)\n", "wrapper (pack, args)", "ticks", ITERS, REPS);
-	printf("---------------------------------------------\n");
-
 	void (* volatile think)(edict_t *) = dll.pfnThink;
 	void (* volatile use)(edict_t *, edict_t *) = dll.pfnUse;
 	void (* volatile activate)(edict_t *, int, int) = dll.pfnServerActivate;
@@ -178,15 +285,34 @@ int main(void)
 	void (* volatile playback)(int, const edict_t *, unsigned short, float, float *, float *,
 				   float, float, int, int, int, int) = meta_engfuncs.pfnPlaybackEvent;
 
-	BENCH("dllapi Think (p, 1)",        , (void)0, think(&ed));
-	BENCH("dllapi Use (2p, 2)",         , (void)0, use(&ed, &ed));
-	BENCH("dllapi ServerActivate (p2i, 3)", , (void)0, activate(&ed, 32, 16));
-	BENCH("dllapi SaveWriteFields (4pi, 5)", , (void)0, savefields(&srd, "n", &srd, &td, 1));
-	BENCH("engine SetModel (2p, 2)",    , (void)0, setmodel(&ed, "m"));
-	BENCH("engine RunPlayerMove (2p3fus2uc, 8)", , (void)0,
-	      runmove(&ed, vec, 1.0f, 2.0f, 3.0f, (unsigned short)0x1234, (byte)7, (byte)13));
-	BENCH("engine PlaybackEvent (ipusf2p2f4i, 12)", , (void)0,
-	      playback(1, &ed, (unsigned short)0x5678, 0.5f, vec, vec, 1.5f, 2.5f, 3, 4, 5, 6));
+	for (c = 0; c < NCONFIGS; c++) {
+		setup_plugins(configs[c].nplugins, configs[c].khooks, configs[c].with_post);
+
+		BENCH(results[c][0], think(&ed));
+		BENCH(results[c][1], use(&ed, &ed));
+		BENCH(results[c][2], activate(&ed, 32, 16));
+		BENCH(results[c][3], savefields(&srd, "n", &srd, &td, 1));
+		BENCH(results[c][4], setmodel(&ed, "m"));
+		BENCH(results[c][5], runmove(&ed, vec, 1.0f, 2.0f, 3.0f,
+					     (unsigned short)0x1234, (byte)7, (byte)13));
+		BENCH(results[c][6], playback(1, &ed, (unsigned short)0x5678, 0.5f, vec, vec,
+					      1.5f, 2.5f, 3, 4, 5, 6));
+	}
+
+	printf("TSC ticks per call (%d iters, best of %d)\n\n", ITERS, REPS);
+	printf("%-40s", "wrapper (pack, args)");
+	for (c = 0; c < NCONFIGS; c++)
+		printf("%15s", configs[c].label);
+	printf("\n");
+	for (c = 0; c < 40 + 15 * NCONFIGS; c++)
+		printf("-");
+	printf("\n");
+	for (w = 0; w < NWRAPPERS; w++) {
+		printf("%-40s", wrapper_names[w]);
+		for (c = 0; c < NCONFIGS; c++)
+			printf("%15.1f", results[c][w]);
+		printf("\n");
+	}
 
 	return 0;
 }

--- a/metamod/tests/test_api_hook.cpp
+++ b/metamod/tests/test_api_hook.cpp
@@ -296,6 +296,17 @@ static void teardown(void)
 	GameDLL_funcs.dllapi_table = NULL;
 }
 
+// Hook lists are per function, so which functions a plugin hooks is decided
+// when the lists are built.  At runtime that ordering is metamod's: a plugin
+// fills its table while attaching and the rebuild follows.  A test sets its
+// table up after the setup_*_plugin() helpers have already rebuilt, so the
+// rebuild has to happen once more before dispatching.
+static void rebuild_before_dispatch(void)
+{
+	if(Plugins)
+		Plugins->rebuild_hook_lists();
+}
+
 // Helper: call GameDLLInit through the hook dispatcher
 static void call_hooked_GameInit(void)
 {
@@ -303,6 +314,7 @@ static void call_hooked_GameInit(void)
 	memset(&meta_funcs, 0, sizeof(meta_funcs));
 	int ver = INTERFACE_VERSION;
 	GetEntityAPI2(&meta_funcs, &ver);
+	rebuild_before_dispatch();
 	meta_funcs.pfnGameInit();
 }
 
@@ -315,6 +327,7 @@ static int call_hooked_Spawn(void)
 	GetEntityAPI2(&meta_funcs, &ver);
 	edict_t ed;
 	memset(&ed, 0, sizeof(ed));
+	rebuild_before_dispatch();
 	return meta_funcs.pfnSpawn(&ed);
 }
 
@@ -1582,6 +1595,222 @@ static int test_reentry_does_not_clobber_outer_flag(void)
 }
 
 // ============================================================
+// Per-function hook lists
+// ============================================================
+
+// Which functions a plugin hooks is decided when the lists are built, so
+// removing and adding a hook are not symmetric: a slot that went NULL is
+// skipped on the next call, a slot that was filled is not reached until the
+// lists are rebuilt.  Both are checked here because a plugin holds the
+// pointer to the table metamod handed it and can write to it whenever.
+
+static void plugin1_pre_GameInit_unload_plugin2(void)
+{
+	g_plugin1_pre_called++;
+
+	// A plugin unloading another one from inside a hook, while the pre
+	// loop is still iterating and has plugin2 ahead of it.
+	Plugins->plist[1].status = PL_EMPTY;
+	Plugins->plist[1].tables.dllapi = NULL;
+	Plugins->plist[1].post_tables.dllapi = NULL;
+	Plugins->rebuild_hook_lists();
+
+	RETURN_META(MRES_IGNORED);
+}
+
+static int test_unload_during_pre_iteration_skips_plugin(void)
+{
+	TEST("issue #108 - plugin unloaded mid-iteration is not called, later one still is");
+	setup_two_plugins();
+
+	// A third plugin behind plugin2, to show the loop carries on correctly
+	// after the entry it was about to reach disappears.
+	memset(&plugin3_pre_funcs, 0, sizeof(plugin3_pre_funcs));
+	memset(&plugin3_post_funcs, 0, sizeof(plugin3_post_funcs));
+	plugin3_pre_funcs.pfnGameInit = plugin3_pre_GameInit;
+	MPlugin *plug3 = &test_plugins.plist[2];
+	memset(plug3, 0, sizeof(*plug3));
+	plug3->status = PL_RUNNING;
+	plug3->index = 3;
+	snprintf(plug3->filename, sizeof(plug3->filename), "plugin3");
+	plug3->file = plug3->filename;
+	plug3->tables.dllapi = &plugin3_pre_funcs;
+	test_plugins.endlist = 3;
+
+	plugin1_pre_funcs.pfnGameInit = plugin1_pre_GameInit_unload_plugin2;
+	plugin2_pre_funcs.pfnGameInit = plugin2_pre_GameInit;
+	g_plugin2_pre_mres = MRES_IGNORED;
+	g_plugin3_pre_called = 0;
+	g_plugin3_post_called = 0;
+
+	call_hooked_GameInit();
+
+	ASSERT_TRUE(g_plugin1_pre_called == 1);
+	ASSERT_TRUE(g_plugin2_pre_called == 0);
+	ASSERT_TRUE(g_plugin3_pre_called == 1);
+	ASSERT_TRUE(g_gamedll_called == 1);
+	teardown();
+	PASS();
+	return 0;
+}
+
+// Dispatch without rebuilding first, to see the lists as a plugin that
+// edits its own table between calls would leave them.
+static void call_hooked_GameInit_no_rebuild(void)
+{
+	DLL_FUNCTIONS meta_funcs;
+	memset(&meta_funcs, 0, sizeof(meta_funcs));
+	int ver = INTERFACE_VERSION;
+	GetEntityAPI2(&meta_funcs, &ver);
+	meta_funcs.pfnGameInit();
+}
+
+static int test_hook_cleared_after_rebuild_is_skipped(void)
+{
+	TEST("per-function lists - hook cleared after rebuild is skipped");
+	setup_two_plugins();
+	plugin1_pre_funcs.pfnGameInit = plugin1_pre_GameInit;
+	plugin2_pre_funcs.pfnGameInit = plugin2_pre_GameInit;
+	g_plugin1_pre_mres = MRES_IGNORED;
+	g_plugin2_pre_mres = MRES_IGNORED;
+	test_plugins.rebuild_hook_lists();
+
+	// plugin1 drops its hook without telling anyone.
+	plugin1_pre_funcs.pfnGameInit = NULL;
+
+	call_hooked_GameInit_no_rebuild();
+
+	ASSERT_TRUE(g_plugin1_pre_called == 0);
+	ASSERT_TRUE(g_plugin2_pre_called == 1);
+	ASSERT_TRUE(g_gamedll_called == 1);
+	teardown();
+	PASS();
+	return 0;
+}
+
+static int test_hook_added_after_rebuild_waits_for_rebuild(void)
+{
+	TEST("per-function lists - hook added after rebuild waits for the next rebuild");
+	setup_two_plugins();
+	plugin2_pre_funcs.pfnGameInit = plugin2_pre_GameInit;
+	g_plugin2_pre_mres = MRES_IGNORED;
+	g_plugin1_pre_mres = MRES_IGNORED;
+	test_plugins.rebuild_hook_lists();
+
+	// plugin1 installs a hook after the lists were built.
+	plugin1_pre_funcs.pfnGameInit = plugin1_pre_GameInit;
+
+	call_hooked_GameInit_no_rebuild();
+	ASSERT_TRUE(g_plugin1_pre_called == 0);
+	ASSERT_TRUE(g_plugin2_pre_called == 1);
+
+	// Load, unload, pause and unpause all rebuild, and then it is called.
+	test_plugins.rebuild_hook_lists();
+	call_hooked_GameInit_no_rebuild();
+	ASSERT_TRUE(g_plugin1_pre_called == 1);
+	ASSERT_TRUE(g_plugin2_pre_called == 2);
+
+	teardown();
+	PASS();
+	return 0;
+}
+
+// ============================================================
+// Hooks installed while running
+// ============================================================
+
+// A plugin owns the table metamod handed it and may edit it at any time.
+// AMX Mod X's fakemeta register_forward() installs hooks exactly that way,
+// long after the plugin attached, so the per-function lists have to notice.
+
+static int g_plugin1_startframe_called;
+static int g_gamedll_startframe_called;
+
+static void plugin1_pre_StartFrame(void)
+{
+	g_plugin1_startframe_called++;
+	RETURN_META(MRES_IGNORED);
+}
+
+static void mock_gamedll_startframe(void)
+{
+	g_gamedll_startframe_called++;
+}
+
+static void call_hooked_StartFrame(void)
+{
+	DLL_FUNCTIONS meta_funcs;
+	memset(&meta_funcs, 0, sizeof(meta_funcs));
+	int ver = INTERFACE_VERSION;
+	GetEntityAPI2(&meta_funcs, &ver);
+	meta_funcs.pfnStartFrame();
+}
+
+static int test_runtime_hook_install_is_picked_up(void)
+{
+	TEST("dynamic hooks - hook installed while running goes live on the next frame");
+	setup_one_plugin();
+	gamedll_funcs.pfnStartFrame = mock_gamedll_startframe;
+	g_plugin1_startframe_called = 0;
+	g_gamedll_startframe_called = 0;
+	test_plugins.rebuild_hook_lists();
+
+	// Nobody hooks StartFrame yet.
+	call_hooked_StartFrame();
+	ASSERT_TRUE(g_plugin1_startframe_called == 0);
+	ASSERT_TRUE(g_gamedll_startframe_called == 1);
+
+	// The plugin installs a hook into its own table and tells nobody.
+	plugin1_pre_funcs.pfnStartFrame = plugin1_pre_StartFrame;
+
+	// The next frame notices and calls it, and keeps calling it.
+	call_hooked_StartFrame();
+	ASSERT_TRUE(g_plugin1_startframe_called == 1);
+	call_hooked_StartFrame();
+	ASSERT_TRUE(g_plugin1_startframe_called == 2);
+	ASSERT_TRUE(g_gamedll_startframe_called == 3);
+
+	// And dropping it again takes effect immediately.
+	plugin1_pre_funcs.pfnStartFrame = NULL;
+	call_hooked_StartFrame();
+	ASSERT_TRUE(g_plugin1_startframe_called == 2);
+	ASSERT_TRUE(g_gamedll_startframe_called == 4);
+
+	gamedll_funcs.pfnStartFrame = NULL;
+	teardown();
+	PASS();
+	return 0;
+}
+
+// The check runs every frame, so it must not rebuild when nothing changed:
+// a rebuild reallocates and invalidates any iteration in flight.
+static int test_unchanged_tables_do_not_rebuild(void)
+{
+	TEST("dynamic hooks - unchanged tables do not trigger a rebuild");
+	setup_one_plugin();
+	gamedll_funcs.pfnStartFrame = mock_gamedll_startframe;
+	plugin1_pre_funcs.pfnStartFrame = plugin1_pre_StartFrame;
+	test_plugins.rebuild_hook_lists();
+
+	MPlugin * const *plugs_before =
+		test_plugins.get_hook_list(e_api_dllapi, offsetof(DLL_FUNCTIONS, pfnStartFrame))->plugs;
+
+	ASSERT_TRUE(test_plugins.hook_tables_changed() == mFALSE);
+	call_hooked_StartFrame();
+	ASSERT_TRUE(test_plugins.hook_tables_changed() == mFALSE);
+
+	// No rebuild means the backing allocation was left alone.
+	ASSERT_PTR_EQ(test_plugins.get_hook_list(e_api_dllapi,
+			offsetof(DLL_FUNCTIONS, pfnStartFrame))->plugs, plugs_before);
+
+	gamedll_funcs.pfnStartFrame = NULL;
+	plugin1_pre_funcs.pfnStartFrame = NULL;
+	teardown();
+	PASS();
+	return 0;
+}
+
+// ============================================================
 // main
 // ============================================================
 
@@ -1666,6 +1895,15 @@ int main(void)
 	fail |= test_flag_cleared_after_outermost_returns();
 	fail |= test_reentry_rebuild_propagates_return_type();
 	fail |= test_reentry_does_not_clobber_outer_flag();
+	fail |= test_unload_during_pre_iteration_skips_plugin();
+
+	// Per-function hook lists
+	fail |= test_hook_cleared_after_rebuild_is_skipped();
+	fail |= test_hook_added_after_rebuild_waits_for_rebuild();
+
+	// Hooks installed while running
+	fail |= test_runtime_hook_install_is_picked_up();
+	fail |= test_unchanged_tables_do_not_rebuild();
 
 	printf("\n%d/%d tests passed\n", tests_passed, tests_run);
 	return fail ? EXIT_FAILURE : EXIT_SUCCESS;

--- a/metamod/tests/test_mlist.cpp
+++ b/metamod/tests/test_mlist.cpp
@@ -4105,6 +4105,25 @@ static DLL_FUNCTIONS fake_dllapi2;
 static NEW_DLL_FUNCTIONS fake_newapi;
 static enginefuncs_t fake_engine_funcs;
 
+// Hook lists are kept per API function, so a fake table has to hook
+// something for its plugin to land in a list at all.  One slot per api
+// group, never called, only looked up.
+static int fake_hook_spawn(edict_t *) { return 0; }
+static void fake_hook_think(edict_t *) {}
+static int fake_hook_precache_model(char *) { return 0; }
+static void fake_hook_game_shutdown(void) {}
+
+#define FAKE_OFF_ENGINE	offsetof(enginefuncs_t, pfnPrecacheModel)
+#define FAKE_OFF_DLLAPI	offsetof(DLL_FUNCTIONS, pfnSpawn)
+#define FAKE_OFF_NEWAPI	offsetof(NEW_DLL_FUNCTIONS, pfnGameShutdown)
+
+// Indexed by enum_api_t, for the tests that loop over all three groups.
+static const unsigned int fake_api_offsets[3] = {
+	FAKE_OFF_ENGINE,
+	FAKE_OFF_DLLAPI,
+	FAKE_OFF_NEWAPI,
+};
+
 static int test_rebuild_empty(void)
 {
 	TEST("rebuild_hook_lists - empty list produces zero counts");
@@ -4113,8 +4132,8 @@ static int test_rebuild_empty(void)
 	list->endlist = 0;
 	list->rebuild_hook_lists();
 	for(int api = 0; api < 3; api++) {
-		ASSERT_INT(list->get_hook_list((enum_api_t)api)->count, 0);
-		ASSERT_INT(list->get_hook_post_list((enum_api_t)api)->count, 0);
+		ASSERT_INT(list->get_hook_list((enum_api_t)api, fake_api_offsets[api])->count, 0);
+		ASSERT_INT(list->get_hook_post_list((enum_api_t)api, fake_api_offsets[api])->count, 0);
 	}
 	ASSERT_TRUE(list->hook_list_data == NULL);
 	teardown_globals();
@@ -4129,6 +4148,7 @@ static int test_rebuild_one_running_dllapi(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	MPlugin *plug = &list->plist[0];
 	memset(plug, 0, sizeof(*plug));
 	plug->status = PL_RUNNING;
@@ -4138,14 +4158,14 @@ static int test_rebuild_one_running_dllapi(void)
 
 	list->rebuild_hook_lists();
 
-	ASSERT_INT(list->get_hook_list(e_api_engine)->count, 0);
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
-	ASSERT_INT(list->get_hook_list(e_api_newapi)->count, 0);
-	ASSERT_INT(list->get_hook_post_list(e_api_engine)->count, 0);
-	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 1);
-	ASSERT_INT(list->get_hook_post_list(e_api_newapi)->count, 0);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug);
-	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi)->plugs[0], plug);
+	ASSERT_INT(list->get_hook_list(e_api_engine, FAKE_OFF_ENGINE)->count, 0);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_INT(list->get_hook_list(e_api_newapi, FAKE_OFF_NEWAPI)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_engine, FAKE_OFF_ENGINE)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_INT(list->get_hook_post_list(e_api_newapi, FAKE_OFF_NEWAPI)->count, 0);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug);
 	teardown_globals();
 	PASS();
 	return 0;
@@ -4158,8 +4178,11 @@ static int test_rebuild_one_running_all_tables(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_newapi, 0, sizeof(fake_newapi));
+	fake_newapi.pfnGameShutdown = fake_hook_game_shutdown;
 	memset(&fake_engine_funcs, 0, sizeof(fake_engine_funcs));
+	fake_engine_funcs.pfnPrecacheModel = fake_hook_precache_model;
 	MPlugin *plug = &list->plist[0];
 	memset(plug, 0, sizeof(*plug));
 	plug->status = PL_RUNNING;
@@ -4174,10 +4197,10 @@ static int test_rebuild_one_running_all_tables(void)
 	list->rebuild_hook_lists();
 
 	for(int api = 0; api < 3; api++) {
-		ASSERT_INT(list->get_hook_list((enum_api_t)api)->count, 1);
-		ASSERT_INT(list->get_hook_post_list((enum_api_t)api)->count, 1);
-		ASSERT_PTR_EQ(list->get_hook_list((enum_api_t)api)->plugs[0], plug);
-		ASSERT_PTR_EQ(list->get_hook_post_list((enum_api_t)api)->plugs[0], plug);
+		ASSERT_INT(list->get_hook_list((enum_api_t)api, fake_api_offsets[api])->count, 1);
+		ASSERT_INT(list->get_hook_post_list((enum_api_t)api, fake_api_offsets[api])->count, 1);
+		ASSERT_PTR_EQ(list->get_hook_list((enum_api_t)api, fake_api_offsets[api])->plugs[0], plug);
+		ASSERT_PTR_EQ(list->get_hook_post_list((enum_api_t)api, fake_api_offsets[api])->plugs[0], plug);
 	}
 	teardown_globals();
 	PASS();
@@ -4191,6 +4214,7 @@ static int test_rebuild_pre_only(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	MPlugin *plug = &list->plist[0];
 	memset(plug, 0, sizeof(*plug));
 	plug->status = PL_RUNNING;
@@ -4200,10 +4224,10 @@ static int test_rebuild_pre_only(void)
 
 	list->rebuild_hook_lists();
 
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
-	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 0);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug);
-	ASSERT_PTR_NULL(list->get_hook_post_list(e_api_dllapi)->plugs);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 0);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug);
+	ASSERT_PTR_NULL(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs);
 	teardown_globals();
 	PASS();
 	return 0;
@@ -4216,6 +4240,7 @@ static int test_rebuild_post_only(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	MPlugin *plug = &list->plist[0];
 	memset(plug, 0, sizeof(*plug));
 	plug->status = PL_RUNNING;
@@ -4225,10 +4250,10 @@ static int test_rebuild_post_only(void)
 
 	list->rebuild_hook_lists();
 
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 0);
-	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 1);
-	ASSERT_PTR_NULL(list->get_hook_list(e_api_dllapi)->plugs);
-	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi)->plugs[0], plug);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_PTR_NULL(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug);
 	teardown_globals();
 	PASS();
 	return 0;
@@ -4241,6 +4266,7 @@ static int test_rebuild_skips_non_running(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 
 	PLUG_STATUS skip_statuses[] = { PL_PAUSED, PL_EMPTY, PL_VALID, PL_OPENED };
 	for(int s = 0; s < 4; s++) {
@@ -4255,8 +4281,8 @@ static int test_rebuild_skips_non_running(void)
 	list->rebuild_hook_lists();
 
 	for(int api = 0; api < 3; api++) {
-		ASSERT_INT(list->get_hook_list((enum_api_t)api)->count, 0);
-		ASSERT_INT(list->get_hook_post_list((enum_api_t)api)->count, 0);
+		ASSERT_INT(list->get_hook_list((enum_api_t)api, fake_api_offsets[api])->count, 0);
+		ASSERT_INT(list->get_hook_post_list((enum_api_t)api, fake_api_offsets[api])->count, 0);
 	}
 	teardown_globals();
 	PASS();
@@ -4270,7 +4296,9 @@ static int test_rebuild_mixed_statuses(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plug0 = &list->plist[0];
 	memset(plug0, 0, sizeof(*plug0));
@@ -4295,9 +4323,9 @@ static int test_rebuild_mixed_statuses(void)
 	list->endlist = 4;
 	list->rebuild_hook_lists();
 
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 2);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug1);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[1], plug3);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 2);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[1], plug3);
 	teardown_globals();
 	PASS();
 	return 0;
@@ -4310,7 +4338,9 @@ static int test_rebuild_two_plugins_order(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plug0 = &list->plist[0];
 	memset(plug0, 0, sizeof(*plug0));
@@ -4327,12 +4357,12 @@ static int test_rebuild_two_plugins_order(void)
 	list->endlist = 2;
 	list->rebuild_hook_lists();
 
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 2);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug0);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[1], plug1);
-	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 2);
-	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi)->plugs[0], plug0);
-	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi)->plugs[1], plug1);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 2);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug0);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[1], plug1);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 2);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug0);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[1], plug1);
 	teardown_globals();
 	PASS();
 	return 0;
@@ -4345,8 +4375,11 @@ static int test_rebuild_different_api_groups(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_newapi, 0, sizeof(fake_newapi));
+	fake_newapi.pfnGameShutdown = fake_hook_game_shutdown;
 	memset(&fake_engine_funcs, 0, sizeof(fake_engine_funcs));
+	fake_engine_funcs.pfnPrecacheModel = fake_hook_precache_model;
 
 	MPlugin *plug0 = &list->plist[0];
 	memset(plug0, 0, sizeof(*plug0));
@@ -4362,15 +4395,15 @@ static int test_rebuild_different_api_groups(void)
 	list->endlist = 2;
 	list->rebuild_hook_lists();
 
-	ASSERT_INT(list->get_hook_list(e_api_engine)->count, 1);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_engine)->plugs[0], plug0);
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug1);
-	ASSERT_INT(list->get_hook_list(e_api_newapi)->count, 0);
-	ASSERT_INT(list->get_hook_post_list(e_api_engine)->count, 0);
-	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 0);
-	ASSERT_INT(list->get_hook_post_list(e_api_newapi)->count, 1);
-	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_newapi)->plugs[0], plug1);
+	ASSERT_INT(list->get_hook_list(e_api_engine, FAKE_OFF_ENGINE)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_engine, FAKE_OFF_ENGINE)->plugs[0], plug0);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug1);
+	ASSERT_INT(list->get_hook_list(e_api_newapi, FAKE_OFF_NEWAPI)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_engine, FAKE_OFF_ENGINE)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_newapi, FAKE_OFF_NEWAPI)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_newapi, FAKE_OFF_NEWAPI)->plugs[0], plug1);
 	teardown_globals();
 	PASS();
 	return 0;
@@ -4383,7 +4416,9 @@ static int test_rebuild_realloc_shrinks(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plug0 = &list->plist[0];
 	memset(plug0, 0, sizeof(*plug0));
@@ -4397,12 +4432,12 @@ static int test_rebuild_realloc_shrinks(void)
 
 	list->endlist = 2;
 	list->rebuild_hook_lists();
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 2);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 2);
 
 	plug1->status = PL_EMPTY;
 	list->rebuild_hook_lists();
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug0);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug0);
 	teardown_globals();
 	PASS();
 	return 0;
@@ -4415,6 +4450,7 @@ static int test_rebuild_realloc_failure_keeps_old(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	MPlugin *plug = &list->plist[0];
 	memset(plug, 0, sizeof(*plug));
 	plug->status = PL_RUNNING;
@@ -4422,12 +4458,13 @@ static int test_rebuild_realloc_failure_keeps_old(void)
 	list->endlist = 1;
 
 	list->rebuild_hook_lists();
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
 	MPlugin **old_data = list->hook_list_data;
 	ASSERT_PTR_NOT_NULL(old_data);
 
 	// Add a second plugin and force realloc to fail
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	MPlugin *plug1 = &list->plist[1];
 	memset(plug1, 0, sizeof(*plug1));
 	plug1->status = PL_RUNNING;
@@ -4440,8 +4477,8 @@ static int test_rebuild_realloc_failure_keeps_old(void)
 
 	// Old allocation preserved, but lists zeroed so dispatch is safe
 	ASSERT_PTR_EQ(list->hook_list_data, old_data);
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 0);
-	ASSERT_PTR_NULL(list->get_hook_list(e_api_dllapi)->plugs);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 0);
+	ASSERT_PTR_NULL(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs);
 	teardown_globals();
 	PASS();
 	return 0;
@@ -4454,6 +4491,7 @@ static int test_rebuild_to_empty_frees(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	MPlugin *plug = &list->plist[0];
 	memset(plug, 0, sizeof(*plug));
 	plug->status = PL_RUNNING;
@@ -4467,8 +4505,8 @@ static int test_rebuild_to_empty_frees(void)
 	list->rebuild_hook_lists();
 	ASSERT_PTR_NULL(list->hook_list_data);
 	for(int api = 0; api < 3; api++) {
-		ASSERT_INT(list->get_hook_list((enum_api_t)api)->count, 0);
-		ASSERT_INT(list->get_hook_post_list((enum_api_t)api)->count, 0);
+		ASSERT_INT(list->get_hook_list((enum_api_t)api, fake_api_offsets[api])->count, 0);
+		ASSERT_INT(list->get_hook_post_list((enum_api_t)api, fake_api_offsets[api])->count, 0);
 	}
 	teardown_globals();
 	PASS();
@@ -4495,8 +4533,8 @@ static int test_rebuild_null_tables_ignored(void)
 	list->rebuild_hook_lists();
 
 	for(int api = 0; api < 3; api++) {
-		ASSERT_INT(list->get_hook_list((enum_api_t)api)->count, 0);
-		ASSERT_INT(list->get_hook_post_list((enum_api_t)api)->count, 0);
+		ASSERT_INT(list->get_hook_list((enum_api_t)api, fake_api_offsets[api])->count, 0);
+		ASSERT_INT(list->get_hook_post_list((enum_api_t)api, fake_api_offsets[api])->count, 0);
 	}
 	ASSERT_PTR_NULL(list->hook_list_data);
 	teardown_globals();
@@ -4511,7 +4549,9 @@ static int test_rebuild_plugs_contiguous(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_engine_funcs, 0, sizeof(fake_engine_funcs));
+	fake_engine_funcs.pfnPrecacheModel = fake_hook_precache_model;
 
 	MPlugin *plug0 = &list->plist[0];
 	memset(plug0, 0, sizeof(*plug0));
@@ -4528,9 +4568,9 @@ static int test_rebuild_plugs_contiguous(void)
 	ASSERT_PTR_NOT_NULL(base);
 
 	// engine pre (1) + engine post (0) + dllapi pre (1) + dllapi post (1) = 3 total
-	const api_plugin_list_t *eng_pre = list->get_hook_list(e_api_engine);
-	const api_plugin_list_t *dll_pre = list->get_hook_list(e_api_dllapi);
-	const api_plugin_list_t *dll_post = list->get_hook_post_list(e_api_dllapi);
+	const api_plugin_list_t *eng_pre = list->get_hook_list(e_api_engine, FAKE_OFF_ENGINE);
+	const api_plugin_list_t *dll_pre = list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI);
+	const api_plugin_list_t *dll_post = list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI);
 
 	ASSERT_PTR_EQ(eng_pre->plugs, base);
 	ASSERT_PTR_EQ(dll_pre->plugs, base + 1);
@@ -4547,6 +4587,7 @@ static int test_rebuild_repeated_calls(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	MPlugin *plug = &list->plist[0];
 	memset(plug, 0, sizeof(*plug));
 	plug->status = PL_RUNNING;
@@ -4555,14 +4596,14 @@ static int test_rebuild_repeated_calls(void)
 	list->endlist = 1;
 
 	list->rebuild_hook_lists();
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
-	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 1);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
 
 	list->rebuild_hook_lists();
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
-	ASSERT_INT(list->get_hook_post_list(e_api_dllapi)->count, 1);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug);
-	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi)->plugs[0], plug);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug);
 	teardown_globals();
 	PASS();
 	return 0;
@@ -4575,7 +4616,9 @@ static int test_rebuild_endlist_bounds(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plug0 = &list->plist[0];
 	memset(plug0, 0, sizeof(*plug0));
@@ -4590,8 +4633,191 @@ static int test_rebuild_endlist_bounds(void)
 	list->endlist = 1;
 	list->rebuild_hook_lists();
 
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 1);
-	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi)->plugs[0], plug0);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs[0], plug0);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// ============================================================
+// rebuild_hook_lists: per-function granularity
+// ============================================================
+
+// A table is what a plugin registers; the slots it fills are what it hooks.
+// Registering a table it never fills hooks nothing.
+static int test_rebuild_empty_table_hooks_nothing(void)
+{
+	TEST("rebuild_hook_lists - table with no hooks lands in no list");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.dllapi = &fake_dllapi;
+	plug->post_tables.dllapi = &fake_dllapi;
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 0);
+	ASSERT_TRUE(list->hook_list_data == NULL);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// mplugin.cpp allocates a plugin's engine table without the reserved
+// extra_functions tail, so rebuild_hook_lists() must not scan past what a
+// plugin can fill.  The table is allocated here the same way, and on the
+// heap, so a scan that runs off the end is a heap overread that ASan and
+// valgrind will report rather than something that silently reads padding.
+static int test_rebuild_engine_table_not_overread(void)
+{
+	TEST("rebuild_hook_lists - plugin engine table is not scanned past its end");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	size_t plugin_engine_size =
+		sizeof(enginefuncs_t) - sizeof(((enginefuncs_t *)0)->extra_functions);
+	enginefuncs_t *eng = (enginefuncs_t *)calloc(1, plugin_engine_size);
+	ASSERT_TRUE(eng != NULL);
+	eng->pfnPrecacheModel = fake_hook_precache_model;
+
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.engine = eng;
+	plug->post_tables.engine = eng;
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+
+	ASSERT_INT(list->get_hook_list(e_api_engine, FAKE_OFF_ENGINE)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_list(e_api_engine, FAKE_OFF_ENGINE)->plugs[0], plug);
+	ASSERT_INT(list->get_hook_post_list(e_api_engine, FAKE_OFF_ENGINE)->count, 1);
+
+	free(eng);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Only running plugins are in the lists, so only their tables are worth
+// watching.  A paused plugin editing its table must not cost a rebuild.
+static int test_hook_tables_changed_ignores_paused(void)
+{
+	TEST("hook_tables_changed - edits by a non-running plugin are ignored");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
+
+	MPlugin *running = &list->plist[0];
+	memset(running, 0, sizeof(*running));
+	running->status = PL_RUNNING;
+	running->tables.dllapi = &fake_dllapi;
+
+	MPlugin *paused = &list->plist[1];
+	memset(paused, 0, sizeof(*paused));
+	paused->status = PL_PAUSED;
+	paused->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+	ASSERT_TRUE(list->hook_tables_changed() == mFALSE);
+
+	// The paused plugin edits its table: nothing to rebuild for.
+	fake_dllapi2.pfnThink = fake_hook_think;
+	ASSERT_TRUE(list->hook_tables_changed() == mFALSE);
+
+	// The running one edits its table: that has to be noticed.
+	fake_dllapi.pfnThink = fake_hook_think;
+	ASSERT_TRUE(list->hook_tables_changed() == mTRUE);
+
+	// And a rebuild puts the snapshot back in step.
+	list->rebuild_hook_lists();
+	ASSERT_TRUE(list->hook_tables_changed() == mFALSE);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, offsetof(DLL_FUNCTIONS, pfnThink))->count, 1);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// Two plugins holding a table for the same group, hooking different
+// functions of it: neither shows up in the other's list.
+static int test_rebuild_separate_list_per_function(void)
+{
+	TEST("rebuild_hook_lists - each function gets its own list");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnThink = fake_hook_think;
+
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->status = PL_RUNNING;
+	plug0->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi2;
+
+	list->endlist = 2;
+	list->rebuild_hook_lists();
+
+	const api_plugin_list_t *spawn = list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI);
+	const api_plugin_list_t *think = list->get_hook_list(e_api_dllapi, offsetof(DLL_FUNCTIONS, pfnThink));
+
+	ASSERT_INT(spawn->count, 1);
+	ASSERT_PTR_EQ(spawn->plugs[0], plug0);
+	ASSERT_INT(think->count, 1);
+	ASSERT_PTR_EQ(think->plugs[0], plug1);
+
+	// A function neither of them hooks stays empty.
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, offsetof(DLL_FUNCTIONS, pfnUse))->count, 0);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
+// The pre and post tables of one plugin can hook different functions.
+static int test_rebuild_post_hooks_per_function(void)
+{
+	TEST("rebuild_hook_lists - post hooks tracked per function");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnThink = fake_hook_think;
+
+	MPlugin *plug = &list->plist[0];
+	memset(plug, 0, sizeof(*plug));
+	plug->status = PL_RUNNING;
+	plug->tables.dllapi = &fake_dllapi;		// pre hooks Spawn
+	plug->post_tables.dllapi = &fake_dllapi2;	// post hooks Think
+	list->endlist = 1;
+
+	list->rebuild_hook_lists();
+
+	unsigned int think_off = offsetof(DLL_FUNCTIONS, pfnThink);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 1);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 0);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, think_off)->count, 0);
+	ASSERT_INT(list->get_hook_post_list(e_api_dllapi, think_off)->count, 1);
+	ASSERT_PTR_EQ(list->get_hook_post_list(e_api_dllapi, think_off)->plugs[0], plug);
 	teardown_globals();
 	PASS();
 	return 0;
@@ -4620,8 +4846,11 @@ static int test_find_after_rebuild_later_removed(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -4639,15 +4868,15 @@ static int test_find_after_rebuild_later_removed(void)
 	list->rebuild_hook_lists();
 
 	// Simulate: at idx=0 calling A, C gets removed, rebuild
-	int count = list->get_hook_list(e_api_dllapi)->count;
-	MPlugin * const *plugs = list->get_hook_list(e_api_dllapi)->plugs;
+	int count = list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count;
+	MPlugin * const *plugs = list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs;
 	ASSERT_INT(count, 3);
 
 	plugC->status = PL_EMPTY; plugC->tables.dllapi = NULL;
 	list->rebuild_hook_lists();
 
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugA, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugA, count, plugs);
 	ASSERT_INT(new_i, 0);
 	ASSERT_INT(count, 2);
 
@@ -4664,8 +4893,11 @@ static int test_find_after_rebuild_later_removed2(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -4688,7 +4920,7 @@ static int test_find_after_rebuild_later_removed2(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 1);
 	ASSERT_INT(count, 2);
 
@@ -4705,8 +4937,11 @@ static int test_find_after_rebuild_later_added(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -4729,7 +4964,7 @@ static int test_find_after_rebuild_later_added(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugA, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugA, count, plugs);
 	ASSERT_INT(new_i, 0);
 	ASSERT_INT(count, 3);
 
@@ -4746,8 +4981,11 @@ static int test_find_after_rebuild_earlier_removed(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -4770,7 +5008,7 @@ static int test_find_after_rebuild_earlier_removed(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugC, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugC, count, plugs);
 	ASSERT_INT(new_i, 1);
 	ASSERT_INT(count, 2);
 
@@ -4787,8 +5025,11 @@ static int test_find_after_rebuild_earlier_paused(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -4811,7 +5052,7 @@ static int test_find_after_rebuild_earlier_paused(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugC, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugC, count, plugs);
 	ASSERT_INT(new_i, 1);
 	ASSERT_INT(count, 2);
 
@@ -4828,8 +5069,11 @@ static int test_find_after_rebuild_two_earlier_removed(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -4853,7 +5097,7 @@ static int test_find_after_rebuild_two_earlier_removed(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugC, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugC, count, plugs);
 	ASSERT_INT(new_i, 0);
 	ASSERT_INT(count, 1);
 
@@ -4870,8 +5114,11 @@ static int test_find_after_rebuild_earlier_removed_mid(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -4894,7 +5141,7 @@ static int test_find_after_rebuild_earlier_removed_mid(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 0);
 	ASSERT_INT(count, 2);
 
@@ -4911,7 +5158,9 @@ static int test_find_after_rebuild_earlier_removed_becomes_first(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -4930,7 +5179,7 @@ static int test_find_after_rebuild_earlier_removed_becomes_first(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 0);
 	ASSERT_INT(count, 1);
 
@@ -4947,8 +5196,11 @@ static int test_find_after_rebuild_earlier_added(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 
 	// plist[0] = empty slot for X (added later)
 	// plist[1] = A, plist[2] = B
@@ -4972,7 +5224,7 @@ static int test_find_after_rebuild_earlier_added(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugA, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugA, count, plugs);
 	ASSERT_INT(new_i, 1);
 	ASSERT_INT(count, 3);
 
@@ -4989,8 +5241,11 @@ static int test_find_after_rebuild_earlier_added_last(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[1];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 2;
@@ -5011,7 +5266,7 @@ static int test_find_after_rebuild_earlier_added_last(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 2);
 	ASSERT_INT(count, 3);
 
@@ -5028,8 +5283,11 @@ static int test_find_after_rebuild_added_between(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 
 	// plist[0] = A, plist[1] empty for X, plist[2] = B
 	MPlugin *plugA = &list->plist[0];
@@ -5052,7 +5310,7 @@ static int test_find_after_rebuild_added_between(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 2);
 	ASSERT_INT(count, 3);
 
@@ -5069,9 +5327,13 @@ static int test_find_after_rebuild_two_earlier_added(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi5, 0, sizeof(fake_dllapi5));
+	fake_dllapi5.pfnSpawn = fake_hook_spawn;
 
 	// plist[0],[1] empty for X,Y; plist[2] = A, plist[3] = B
 	MPlugin *plugA = &list->plist[2];
@@ -5098,7 +5360,7 @@ static int test_find_after_rebuild_two_earlier_added(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugA, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugA, count, plugs);
 	ASSERT_INT(new_i, 2);
 	ASSERT_INT(count, 4);
 
@@ -5115,8 +5377,11 @@ static int test_find_after_rebuild_earlier_unpaused(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 
 	// plist[0] = A, plist[1] = X (paused), plist[2] = B
 	MPlugin *plugA = &list->plist[0];
@@ -5134,18 +5399,18 @@ static int test_find_after_rebuild_earlier_unpaused(void)
 	list->endlist = 3;
 	list->rebuild_hook_lists();
 	// Hook list is [A, B] (X paused)
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 2);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 2);
 
 	// Unpause X
 	plugX->status = PL_RUNNING;
 	list->rebuild_hook_lists();
 	// Hook list is [A, X, B]
-	ASSERT_INT(list->get_hook_list(e_api_dllapi)->count, 3);
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count, 3);
 
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 2);
 	ASSERT_INT(count, 3);
 
@@ -5162,6 +5427,7 @@ static int test_find_after_rebuild_self_removed_only(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -5176,7 +5442,7 @@ static int test_find_after_rebuild_self_removed_only(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugA, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugA, count, plugs);
 	// i=-1, loop does i++ → 0, 0<0 false, loop ends
 	ASSERT_INT(new_i, -1);
 	ASSERT_INT(count, 0);
@@ -5194,7 +5460,9 @@ static int test_find_after_rebuild_self_removed_first(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -5213,7 +5481,7 @@ static int test_find_after_rebuild_self_removed_first(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugA, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugA, count, plugs);
 	// i=-1, loop does i++ → 0, processes plugs[0]=B
 	ASSERT_INT(new_i, -1);
 	ASSERT_INT(count, 1);
@@ -5232,8 +5500,11 @@ static int test_find_after_rebuild_self_removed_mid(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -5256,7 +5527,7 @@ static int test_find_after_rebuild_self_removed_mid(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	// i=0, loop does i++ → 1, processes plugs[1]=C
 	ASSERT_INT(new_i, 0);
 	ASSERT_INT(count, 2);
@@ -5275,8 +5546,11 @@ static int test_find_after_rebuild_self_paused_mid(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -5299,7 +5573,7 @@ static int test_find_after_rebuild_self_paused_mid(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 0);
 	ASSERT_INT(count, 2);
 	ASSERT_PTR_EQ(plugs[1], plugC);
@@ -5317,9 +5591,13 @@ static int test_find_after_rebuild_mixed_remove_add_later(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -5346,7 +5624,7 @@ static int test_find_after_rebuild_mixed_remove_add_later(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 0);
 	ASSERT_INT(count, 3);
 
@@ -5363,9 +5641,13 @@ static int test_find_after_rebuild_mixed_remove_add_earlier(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 
 	// plist[0] empty for X, plist[1] = A, plist[2] = B, plist[3] = C
 	MPlugin *plugA = &list->plist[1];
@@ -5394,7 +5676,7 @@ static int test_find_after_rebuild_mixed_remove_add_earlier(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 1);
 	ASSERT_INT(count, 3);
 
@@ -5411,9 +5693,13 @@ static int test_find_after_rebuild_mixed_last_net_zero(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 
 	// plist[0] empty for X, plist[1] = A, plist[2] = B, plist[3] = C
 	MPlugin *plugA = &list->plist[1];
@@ -5440,7 +5726,7 @@ static int test_find_after_rebuild_mixed_last_net_zero(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugC, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugC, count, plugs);
 	ASSERT_INT(new_i, 2);
 	ASSERT_INT(count, 3);
 
@@ -5457,9 +5743,13 @@ static int test_find_after_rebuild_mixed_add_before_remove_after(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 
 	// plist[0] empty for X, plist[1] = A, plist[2] = B, plist[3] = C
 	MPlugin *plugA = &list->plist[1];
@@ -5487,7 +5777,7 @@ static int test_find_after_rebuild_mixed_add_before_remove_after(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugA, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugA, count, plugs);
 	ASSERT_INT(new_i, 1);
 	ASSERT_INT(count, 3);
 
@@ -5504,8 +5794,11 @@ static int test_find_after_rebuild_others_removed(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -5529,7 +5822,7 @@ static int test_find_after_rebuild_others_removed(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 0);
 	ASSERT_INT(count, 1);
 
@@ -5546,10 +5839,15 @@ static int test_find_after_rebuild_many_earlier_removed(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi5, 0, sizeof(fake_dllapi5));
+	fake_dllapi5.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -5582,7 +5880,7 @@ static int test_find_after_rebuild_many_earlier_removed(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugE, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugE, count, plugs);
 	ASSERT_INT(new_i, 1);
 	ASSERT_INT(count, 2);
 
@@ -5599,9 +5897,13 @@ static int test_find_after_rebuild_many_earlier_added(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi4, 0, sizeof(fake_dllapi4));
+	fake_dllapi4.pfnSpawn = fake_hook_spawn;
 
 	// plist[0,1,2] empty, plist[3] = A
 	MPlugin *plugA = &list->plist[3];
@@ -5628,7 +5930,7 @@ static int test_find_after_rebuild_many_earlier_added(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugA, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugA, count, plugs);
 	ASSERT_INT(new_i, 3);
 	ASSERT_INT(count, 4);
 
@@ -5645,8 +5947,11 @@ static int test_find_after_rebuild_no_change(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -5667,7 +5972,7 @@ static int test_find_after_rebuild_no_change(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugB, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugB, count, plugs);
 	ASSERT_INT(new_i, 1);
 	ASSERT_INT(count, 3);
 
@@ -5684,8 +5989,11 @@ static int test_find_after_rebuild_self_removed_last(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	MPlugin *plugA = &list->plist[0];
 	memset(plugA, 0, sizeof(*plugA)); plugA->index = 1;
@@ -5708,7 +6016,7 @@ static int test_find_after_rebuild_self_removed_last(void)
 	int count;
 	MPlugin * const *plugs;
 	int new_i = list->find_plugin_after_rebuild(
-		e_api_dllapi, mFALSE, plugC, count, plugs);
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plugC, count, plugs);
 	// i=1, loop does i++ → 2, 2<2 false, loop ends. No plugins skipped.
 	ASSERT_INT(new_i, 1);
 	ASSERT_INT(count, 2);
@@ -5734,8 +6042,11 @@ static int test_rebuild_during_iteration_load(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	// Start with 2 running plugins
 	MPlugin *plug0 = &list->plist[0];
@@ -5754,7 +6065,7 @@ static int test_rebuild_during_iteration_load(void)
 	list->rebuild_hook_lists();
 
 	// Simulate main_hook_function: cache plugs and count
-	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi);
+	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI);
 	int count = hlist->count;
 	MPlugin * const *plugs = hlist->plugs;
 
@@ -5797,8 +6108,11 @@ static int test_rebuild_during_iteration_unload_later(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	// 3 running plugins
 	MPlugin *plug0 = &list->plist[0];
@@ -5823,7 +6137,7 @@ static int test_rebuild_during_iteration_unload_later(void)
 	list->rebuild_hook_lists();
 
 	// Cache like main_hook_function does
-	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi);
+	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI);
 	int count = hlist->count;
 	MPlugin * const *plugs = hlist->plugs;
 
@@ -5855,8 +6169,11 @@ static int test_rebuild_during_iteration_unload_earlier(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	// 3 running plugins
 	MPlugin *plug0 = &list->plist[0];
@@ -5881,7 +6198,7 @@ static int test_rebuild_during_iteration_unload_earlier(void)
 	list->rebuild_hook_lists();
 
 	// Cache like main_hook_function does
-	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi);
+	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI);
 	int count = hlist->count;
 	(void)count;
 
@@ -5918,6 +6235,69 @@ static int test_rebuild_during_iteration_unload_earlier(void)
 	return 0;
 }
 
+// A plugin can leave one function's list while staying a running plugin
+// that hooks others.  find_plugin_after_rebuild has to cope with that the
+// same way it copes with a plugin being unloaded outright.
+static int test_rebuild_during_iteration_drops_this_hook(void)
+{
+	TEST("rebuild during iteration - plugin drops this hook, later ones shift");
+	setup_globals();
+	HeapPluginList list("test.ini");
+
+	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
+	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
+	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
+
+	MPlugin *plug0 = &list->plist[0];
+	memset(plug0, 0, sizeof(*plug0));
+	plug0->index = 1;
+	plug0->status = PL_RUNNING;
+	plug0->tables.dllapi = &fake_dllapi;
+
+	MPlugin *plug1 = &list->plist[1];
+	memset(plug1, 0, sizeof(*plug1));
+	plug1->index = 2;
+	plug1->status = PL_RUNNING;
+	plug1->tables.dllapi = &fake_dllapi2;
+
+	MPlugin *plug2 = &list->plist[2];
+	memset(plug2, 0, sizeof(*plug2));
+	plug2->index = 3;
+	plug2->status = PL_RUNNING;
+	plug2->tables.dllapi = &fake_dllapi3;
+
+	list->endlist = 3;
+	list->rebuild_hook_lists();
+
+	int count = list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->count;
+	MPlugin * const *plugs = list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI)->plugs;
+	ASSERT_INT(count, 3);
+
+	// Iteration is at plug1 (index 1) when plug0 stops hooking Spawn but
+	// keeps running and keeps hooking something else.
+	fake_dllapi.pfnSpawn = NULL;
+	fake_dllapi.pfnThink = fake_hook_think;
+	list->rebuild_hook_lists();
+
+	int new_i = list->find_plugin_after_rebuild(
+		e_api_dllapi, FAKE_OFF_DLLAPI, mFALSE, plug1, count, plugs);
+
+	// plug1 is now first in Spawn's list, and plug2 still follows it.
+	ASSERT_INT(count, 2);
+	ASSERT_INT(new_i, 0);
+	ASSERT_PTR_EQ(plugs[0], plug1);
+	ASSERT_PTR_EQ(plugs[1], plug2);
+
+	// plug0 kept running, so it is in the list of what it does hook.
+	ASSERT_INT(list->get_hook_list(e_api_dllapi, offsetof(DLL_FUNCTIONS, pfnThink))->count, 1);
+	teardown_globals();
+	PASS();
+	return 0;
+}
+
 static int test_rebuild_during_iteration_load_post(void)
 {
 	TEST("rebuild during post iteration - load invalidates cached plugs");
@@ -5925,8 +6305,11 @@ static int test_rebuild_during_iteration_load_post(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	// 2 running plugins with post tables
 	MPlugin *plug0 = &list->plist[0];
@@ -5945,7 +6328,7 @@ static int test_rebuild_during_iteration_load_post(void)
 	list->rebuild_hook_lists();
 
 	// Cache post hook list like main_hook_function does
-	const api_plugin_list_t *hlist = list->get_hook_post_list(e_api_dllapi);
+	const api_plugin_list_t *hlist = list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI);
 	int count = hlist->count;
 	MPlugin * const *plugs = hlist->plugs;
 
@@ -5980,8 +6363,11 @@ static int test_rebuild_during_iteration_unload_earlier_post(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	// 3 running plugins with post tables
 	MPlugin *plug0 = &list->plist[0];
@@ -6006,7 +6392,7 @@ static int test_rebuild_during_iteration_unload_earlier_post(void)
 	list->rebuild_hook_lists();
 
 	// Cache post hook list
-	const api_plugin_list_t *hlist = list->get_hook_post_list(e_api_dllapi);
+	const api_plugin_list_t *hlist = list->get_hook_post_list(e_api_dllapi, FAKE_OFF_DLLAPI);
 	int count = hlist->count;
 	(void)count;
 
@@ -6040,8 +6426,11 @@ static int test_rebuild_during_iteration_segfault(void)
 	HeapPluginList list("test.ini");
 
 	memset(&fake_dllapi, 0, sizeof(fake_dllapi));
+	fake_dllapi.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi2, 0, sizeof(fake_dllapi2));
+	fake_dllapi2.pfnSpawn = fake_hook_spawn;
 	memset(&fake_dllapi3, 0, sizeof(fake_dllapi3));
+	fake_dllapi3.pfnSpawn = fake_hook_spawn;
 
 	// 2 running plugins
 	MPlugin *plug0 = &list->plist[0];
@@ -6060,7 +6449,7 @@ static int test_rebuild_during_iteration_segfault(void)
 	list->rebuild_hook_lists();
 
 	// Simulate main_hook_function: cache plugs and count
-	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi);
+	const api_plugin_list_t *hlist = list->get_hook_list(e_api_dllapi, FAKE_OFF_DLLAPI);
 	int count = hlist->count;
 	MPlugin * const *plugs = hlist->plugs;
 
@@ -6320,6 +6709,11 @@ int main(void)
 	fail |= test_rebuild_plugs_contiguous();
 	fail |= test_rebuild_repeated_calls();
 	fail |= test_rebuild_endlist_bounds();
+	fail |= test_rebuild_empty_table_hooks_nothing();
+	fail |= test_rebuild_engine_table_not_overread();
+	fail |= test_hook_tables_changed_ignores_paused();
+	fail |= test_rebuild_separate_list_per_function();
+	fail |= test_rebuild_post_hooks_per_function();
 
 	// find_plugin_after_rebuild (issue #108)
 	fail |= test_find_after_rebuild_later_removed();
@@ -6353,6 +6747,7 @@ int main(void)
 	fail |= test_rebuild_during_iteration_load();
 	fail |= test_rebuild_during_iteration_unload_later();
 	fail |= test_rebuild_during_iteration_unload_earlier();
+	fail |= test_rebuild_during_iteration_drops_this_hook();
 	fail |= test_rebuild_during_iteration_load_post();
 	fail |= test_rebuild_during_iteration_unload_earlier_post();
 	fail |= test_rebuild_during_iteration_segfault();


### PR DESCRIPTION
Part of #81: steps 1-3 and 5. Deliberately not "closes" - step 4 is not here, and a section below explains why the approach the issue describes for it does not reach most functions.

Dispatch walked every plugin that had registered a table for the api group and tested `pfn_routine` for each one, on every call. `rebuild_hook_lists()` now builds a list per function instead of per group, so the loop only visits plugins that hook the function being called, and a function nobody hooks leaves `count == 0` with the loop body never entered.

`hook_lists` becomes `[3][HOOK_SLOTS_STRIDE][2]`, indexed by (group, slot, phase). A `func_offset` is already a slot index, so `get_hook_lists()` is `hook_lists[api][func_offset / sizeof(void *)]` — a shift, no table load. Packing the three groups back to back instead (214 slots, plus a per-group base to look up) was tried first and measures about 4 ticks worse per call on the shortest wrappers, because that base is one more dependent load ahead of the loads of `count` and `plugs`. The stride costs 12,288 bytes of list headers against 3,424 packed; `sizeof(MPluginList)` goes 434,156 -> 446,396.

Hoisting both phases to the top of `main_hook_function` was also tried and dropped: the pointer then has to survive the plugin calls and gets spilled. Each phase is looked up where it is used, as before, which is faster on every wrapper and keeps `api_hook.cpp` to a 16-line change.

## Numbers

`make -C metamod/tests bench`, extended with N/K configurations — N plugins holding a table for the group, K of them hooking the function called, the other N-K hooking other functions of the same table. Interleaved A/B against the base branch, 8-25 rounds a side, per-cell minima, TSC ticks per call:

| wrapper | N=1 K=1 | N=5 K=1 | N=20 K=2 | N=40 K=2 | N=20 K=0 |
|---|---|---|---|---|---|
| dllapi Think | 19.2 -> 20.4 | 23.4 -> 19.2 | 49.7 -> 25.4 | 79.6 -> 26.6 | 46.1 -> 13.5 |
| dllapi Use | 21.0 -> 21.1 | 24.6 -> 21.0 | 53.4 -> 27.0 | 80.6 -> 28.7 | 47.5 -> 14.9 |
| dllapi ServerActivate | 21.8 -> 22.9 | 25.9 -> 23.0 | 54.9 -> 28.0 | 81.9 -> 28.0 | 48.1 -> 16.3 |
| dllapi SaveWriteFields | 24.5 -> 24.6 | 28.0 -> 25.5 | 61.0 -> 31.2 | 85.3 -> 31.3 | 47.2 -> 16.3 |
| engine SetModel | 21.6 -> 21.8 | 26.0 -> 20.9 | 54.4 -> 26.8 | 81.0 -> 29.1 | 47.5 -> 14.8 |
| engine RunPlayerMove | 29.4 -> 30.3 | 30.7 -> 30.9 | 63.2 -> 36.8 | 89.3 -> 36.8 | 50.7 -> 21.3 |
| engine PlaybackEvent | 34.4 -> 35.0 | 38.2 -> 36.8 | 70.1 -> 45.1 | 95.2 -> 45.9 | 54.1 -> 24.9 |

Cost was linear in plugin count and independent of K; each plugin that did not hook the function still cost about 1.3 ticks per call. It is now flat in N: the N=20 and N=40 columns are within noise of each other.

**N=1 K=1 regresses by 0 to 6%**, about a tick, visible only on the cheapest wrappers. Break-even is between one and five plugins, measured rather than extrapolated: the N=5 column is already 9-20% ahead on five of seven wrappers. Folding the slot index into the wrapper macros would recover that tick, but `main_hook_function` already takes 4-5 arguments under regparm(3), so a fifth goes on the stack; winning would mean packing `api` and `func_offset` into one value and unpacking inside, which is a signature change to both dispatch functions and every wrapper macro in `dllapi.cpp` and `engine_api.cpp`. Not worth a tick on `pfnThink`.

`PlaybackEvent` moves least, and the K=0 column shows why: its floor is 24.9 ticks against 13.5 for `Think`, same dispatch and same single game DLL call, 11 ticks apart. That gap is `pack_args` marshalling 12 arguments against 1.

## Hooks installed while the server runs

The issue is right that this is the part that decides whether per-function lists are usable at all. Dropping a hook is free: the per-call `pfn_routine` NULL check is kept, so a slot that goes NULL is skipped on the next call. Installing one needs the lists rebuilt.

`rebuild_hook_lists()` snapshots each running plugin's tables, and `mm_StartFrame` compares them once per frame before dispatching, rebuilding on a difference. The hook goes live on the frame it is noticed.

Verified against fakemeta rather than a mock: a plugin calling `register_forward(FM_StartFrame, ...)` five seconds after load, on a server with AMX Mod X and 14 metamod plugins. Upstream fires the forward; per-function lists without the snapshot never fire it; with the snapshot it fires. Worth stressing that the middle case passed the whole unit suite — a C stub plugin editing its own table did not reproduce what fakemeta does.

Cost of the compare when nothing changed, measured hot and again after sweeping a 4MB buffer to evict caches:

| plugins | scanned/frame | hot | cold |
|---|---|---|---|
| 5 | 5,180 B | 365 ticks | 1,040 ticks |
| 15 | 15,540 B | 1,038 | 3,317 |
| 50 | 51,800 B | 4,829 | 10,148 |

At 100 fps and 15 plugins that is 0.1-0.33M ticks/s against roughly 1.2M saved on dispatch.

The issue proposes a hand-written SSE2 memcmp. `memcmp` from the C library is used instead: it is already vectorised and IFUNC-dispatched to whatever the host supports rather than fixed at SSE2, and it hits the issue's own target ("well under a microsecond" for five plugins) at 0.12 us. A bit per slot instead of the table copy was also tried — equally exact, since list membership depends only on NULL vs non-NULL and swapping one handler for another needs no rebuild — and touches half the memory, but building the bitmap tests slots one at a time and measures 4,387 ticks a frame at 15 plugins against 1,038. Kept memcmp; the bitmap is the better trade if cache footprint turns out to matter more than the cycles.

## Step 4 does not work as described

The issue proposes swapping a table entry to point straight at the game DLL when nothing hooks that function. For dllapi and newapi that is fine: the engine passes a pointer to its own `DLL_FUNCTIONS` and reads the member on each call, so the entry can be rewritten later.

For engine functions it cannot work. `metamod.cpp:370` hands the game DLL a pointer to `meta_engfuncs`, and the game DLL does `memcpy(&g_engfuncs, pengfuncsFromEngine, sizeof(enginefuncs_t))` — a private copy taken once at startup. Rewriting `meta_engfuncs` afterwards changes nothing. That is 159 of the 214 functions, including the ones the game DLL calls most.

In `cs.so` that copy is `g_engfuncs`, 0x27c bytes in `.bss`, present in `.symtab` but not in `.dynsym` — the library exports 354 functions and zero data objects, so `dlsym` cannot reach it. Getting at it would mean parsing the game DLL's symbol table and writing into another module's private data, and depends on the mod not being stripped and on the symbol keeping its SDK name. Possibly worth it, but it is a different mechanism from the one in the issue, and metamod-r not taking this route is some evidence about its practicality.

Also worth noting before building on step 4: `pfnStartFrame` is now doubly pinned, since the runtime-hook check lives there, and bypass would have to be reversible — a plugin can install a hook for a bypassed function at any time, so the per-frame check would have to drive bypass state as well.

## Two corrections to the figures in the issue

The issue gives 164 engine pointers / 656 bytes / 219 functions. The build has 175 slots, 16 of which are the `extra_functions` tail added under `__METAMOD_BUILD__`, so 159 real ones and 214 in total.

More usefully: `mplugin.cpp:941` allocates a plugin's engine table as `sizeof(enginefuncs_t) - sizeof(extra_functions)`, 636 bytes. Scanning 175 slots reads 64 bytes past every plugin's engine table. This patch did that at first and no existing test caught it, because they all assign a full-size static `enginefuncs_t` rather than allocating the way metamod does. `test_rebuild_engine_table_not_overread` allocates it the same way and fails under ASan with the bug reintroduced. A snapshot memcmp over 656 bytes would land in the same place.

## Testing

`run`, `run-opt`, `run-release` and `sanitize` at 862/862, `valgrind` clean with no leaks, `metamod.so` builds with release flags, and a hand-played session on the patched build with 20 bots produced no metamod warnings.

11 tests added, covering per-function granularity, hooks installed and dropped while running, a plugin leaving one function's list while still running and hooking others, and the engine-table overread above.

`test_mlist.cpp` is most of the diff and is nearly all mechanical: `get_hook_list(api)` gains a `func_offset` in 73 places, and the fake tables now have to hook something, since a zeroed table hooks nothing under the new rule. `test_api_hook.cpp` needed one real change: its helpers set plugin tables after the setup helpers had already rebuilt, the reverse of what happens at runtime, so the dispatch helpers rebuild before dispatching.

## What is not measured

Effect on the server as a whole. The per-frame scan is new cache traffic and what it does to the engine's own cache lands outside anything the benchmark or META_PERFMON can see — the same class of second-order effect that #112 turned out to have. `meta tsc` on a live server with 14 plugins and 20-32 bots gives mean 118.0 ticks against 107.1 over 180s of matched load, about 11 saved per dispatch at 67k-110k dispatches/s, but two runs of the *same* build differed by 18 ticks, so that is one matched pair and not a result. That matches the note in #112 that bot load varies more between runs than changes of this size.

Measurements were taken under WSL2 rather than on bare metal, which is why every figure above is a minimum over interleaved rounds; worth repeating elsewhere before trusting the small ones.
